### PR TITLE
docs: bun migration plan, fork strategy and branching convention

### DIFF
--- a/.claude/skills/bun-migration/SKILL.md
+++ b/.claude/skills/bun-migration/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: bun-migration
+description: Migrate one workspace package in this monorepo from the Node/pnpm/tsx/esbuild toolchain to Bun. Use when converting apps/api, apps/schedules, apps/dokploy, or packages/server to Bun, when replacing tsx/esbuild/pnpm scripts with Bun equivalents, when rewriting a Dockerfile or CI workflow off Node, or when adopting native Bun APIs (Bun.serve, Bun.sql, Bun.password). Follows docs/bun-migration/PLAN.md.
+---
+
+# Migrating a package to Bun
+
+Execute **one package, one phase, one PR**. The phase order in
+[PLAN.md](../../../docs/bun-migration/PLAN.md) §14 is not advisory — Phase 4 will
+fail in confusing ways if Phases 1–3 have not landed.
+
+## Before you start
+
+**Phase 0 must have passed.** `node-pty`, `ssh2`, and `dockerode` have to be verified
+working under Bun before any package is converted. If
+`docs/bun-migration/SPIKE-RESULTS.md` does not exist, run the Phase 0 spike first and
+stop. Converting a package before that gate means potentially unwinding all of it.
+
+Record the package's current numbers before changing anything — install time, build
+time, `node_modules` size, boot time. "Faster and more compact" is the point of this
+work, and an unmeasured migration cannot be shown to have achieved it.
+
+## Per-package procedure
+
+### 1. `package.json`
+
+- `tsx foo.ts` → `bun foo.ts`. `tsx -r dotenv/config foo.ts` → `bun foo.ts` — Bun loads
+  `.env` itself, drop the preload.
+- `tsx watch` → `bun --watch`
+- `rimraf dist && tsc -p tsconfig.json` → `rm -rf dist && bun build ./src/index.ts --target=bun --outdir=dist --minify --sourcemap --packages=external`
+- **Keep `typecheck: tsc --noEmit`.** `bun build` does not typecheck. Deleting this
+  removes the only type safety net.
+- `node dist/index.js` → `bun dist/index.js`
+- `engines` → `{ "bun": ">=1.3.14" }`
+
+Note the output extension: esbuild was configured to emit `.mjs`, `bun build` emits
+`.js`. Update `start` and the Dockerfile `CMD` **in the same commit** or the container
+will not boot.
+
+### 2. Drop dependencies the toolchain no longer needs
+
+`tsx`, `esbuild`, `rimraf`, `dotenv`, `@hono/node-server`, `undici`. Grep for a live
+import before each removal — `redis` and `ioredis` in particular look dead here but
+must be confirmed against `bullmq`'s runtime needs.
+
+### 3. Native deps → `trustedDependencies`
+
+Any dependency with a postinstall (`node-pty`, `ssh2`, `bcrypt`, `better-sqlite3`,
+`sharp`, `cpu-features`, `protobufjs`, `tree-sitter*`, `msgpackr-extract`,
+`core-js-pure`, `@scarf/scarf`) must be listed in root `package.json`
+`trustedDependencies`. Bun skips postinstall otherwise, and the failure surfaces at
+runtime rather than at install — long after you have stopped looking.
+
+### 4. Hono servers
+
+```ts
+// before
+import { serve } from "@hono/node-server";
+serve({ fetch: app.fetch, port });
+
+// after
+export default { port, fetch: app.fetch };
+```
+
+### 5. Native APIs, in this order
+
+**`Bun.password`** — safest, verified compatible with existing `$2b$` hashes in both
+directions (PLAN §2). Every hash call **must** pass `{ algorithm: "bcrypt", cost: 10 }`;
+Bun's default is argon2id, which npm `bcrypt` cannot read and Traefik cannot parse.
+
+**`Bun.sql`** — `drizzle-orm/postgres-js` → `drizzle-orm/bun-sql`, and the migrator
+import alongside it. The `PostgresJsDatabase` type becomes `BunSQLDatabase`. Watch the
+`max: 1` option in `migration.ts` and `reset.ts`. **Run the full migration chain against
+a scratch database from empty before accepting this**, and snapshot any real database
+first — a migration that runs under the new driver is not undone by reverting the driver.
+
+**`Bun.file` / `Bun.write`** — last, and only on paths that are actually hot. Churning
+100 call sites for an unmeasurable win is not worth the review burden.
+
+**Not `Bun.$`.** See CLAUDE.md — `execAsync` handles pre-built command strings and SSH
+dispatch, and `Bun.$` is a correctness regression there with no upside.
+
+### 6. Verify
+
+```bash
+bun install
+bun run --filter <pkg> typecheck
+bun run --filter <pkg> build
+bun dist/index.js          # boots?
+```
+
+Then the package's own smoke test — for `apps/dokploy` that means all six WebSocket
+features by hand (terminal, container terminal, container logs, deployment logs,
+drawer logs, docker stats), plus a login with a **pre-existing** account.
+
+## Special cases
+
+**`packages/server`** — becomes source-only. Delete `esbuild.config.ts`, the `build` /
+`dev` / `esbuild` / `switch:dev` / `switch:prod` scripts, `scripts/switchToSrc.js`, and
+`scripts/switchToDist.js`. Pin `exports` to `./src/*.ts` permanently and drop the
+`require` → `dist/*.cjs.js` conditions. Remove `tsc-alias` and `esbuild-plugin-alias`.
+Also remove `server:build` from CI and the root `server:script` script.
+
+**`apps/dokploy`** — highest risk. Change the interpreter **only** first: run the
+existing `node:http` server under `bun` and see what breaks. Do not rewrite to
+`Bun.serve` in the same step. The WebSocket upgrade path is the most fragile part of
+this migration and must be isolated from every other change. Rewriting the six WS
+servers onto `Bun.serve`'s native handler is a fallback if `node:http` + `ws` proves
+unreliable — not the plan.
+
+**`apps/monitoring`** — Go. Not in scope. Leave it and its Dockerfile and workflow alone.
+
+## Dockerfiles
+
+`Dockerfile`, `Dockerfile.cloud`, `Dockerfile.server`, `Dockerfile.schedule` (not
+`.monitoring`):
+
+- `FROM node:24.4.0-slim` → `FROM oven/bun:1.3.14-slim`
+- Delete `corepack enable` / `corepack prepare pnpm` / `PNPM_HOME` / the `PATH` export
+- Cache mount: id `pnpm` → `bun`, target `/pnpm/store` → `/root/.bun/install/cache`
+- Drop `pnpm install -g tsx`
+- Keep the build-tools apt layer — `node-pty` and `ssh2` still compile from source
+- Keep `tini`; it reaps HEALTHCHECK children and that need is unchanged
+
+**`pnpm deploy --legacy` has no Bun equivalent.** It currently prunes to a production
+`node_modules`. Either `bun install --production` into a fresh stage, or spike
+`bun build --compile` to a single executable — the latter is the bigger win for image
+size and is worth trying on `apps/api` / `apps/schedules` first, where the surface is small.
+
+## CI
+
+```yaml
+- uses: oven-sh/setup-bun@v2
+  with:
+    bun-version: 1.3.14
+- run: bun install --frozen-lockfile
+- run: bun run --filter '*' ${{ matrix.job }}
+```
+
+Delete `pnpm/action-setup`, `actions/setup-node`, and the `pnpm server:build` step —
+`packages/server` no longer builds.
+
+## Report
+
+State what you measured against the baseline (install time, build time, bundle and
+`node_modules` size, boot time), what you verified by hand, and what you did **not**
+verify. If a smoke test was skipped, say so plainly rather than implying full coverage.

--- a/.claude/skills/remove-enterprise-license/SKILL.md
+++ b/.claude/skills/remove-enterprise-license/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: remove-enterprise-license
+description: Remove enterprise license gating from Dokploy so all features (white-label, SSO, SCIM, custom roles, audit log, forward-auth) work without a license key. Use when unlocking enterprise/proprietary features, removing hasValidLicense or enterpriseProcedure checks, deleting the license-key service, router, cron or UI, or dropping the license columns. Covers the permission-semantics trap in getAccessibleServerIds.
+---
+
+# Removing enterprise licensing
+
+Goal: every enterprise feature works with no license key, and nothing calls
+`licenses-api.dokploy.com`.
+
+**Read this first: this is not a no-op.** Three of the 14 gate call sites use the
+license flag to pick between *different access-control behaviors*, and in one of them
+the unlicensed branch is the **more permissive** one. Flipping the flag without the
+mitigation in step 2 takes server visibility away from every non-admin member on a
+running instance.
+
+## The surface
+
+**Predicate** — `hasValidLicense(organizationId)`,
+`packages/server/src/services/proprietary/license-key.ts:10`. Reads two `user` columns:
+`enableEnterpriseFeatures` and `isValidEnterpriseLicense`.
+
+**14 call sites:**
+
+| File | Line | Kind |
+|---|---|---|
+| `packages/server/src/services/server.ts` | 183 | ⚠️ access control |
+| `packages/server/src/services/permission.ts` | 47 | ⚠️ access control |
+| `packages/server/src/services/git-provider.ts` | 105 | ⚠️ access control |
+| `packages/server/src/services/proprietary/whitelabeling.ts` | 27 | feature gate |
+| `packages/server/src/services/proprietary/audit-log.ts` | 27 | feature gate |
+| `packages/server/src/services/proprietary/license-key.ts` | 55 | feature gate |
+| `apps/dokploy/server/api/trpc.ts` | 225 | `enterpriseProcedure` |
+| `apps/dokploy/server/api/routers/server.ts` | 142 | feature gate |
+| `apps/dokploy/server/api/routers/git-provider.ts` | 116 | feature gate |
+| `apps/dokploy/server/api/routers/organization.ts` | 201 | feature gate |
+| `apps/dokploy/server/api/routers/user.ts` | 478 | feature gate |
+| `apps/dokploy/server/api/routers/proprietary/audit-log.ts` | 10 | feature gate |
+| `apps/dokploy/server/api/routers/proprietary/license-key.ts` | 196 | feature gate |
+| `apps/dokploy/server/api/routers/proprietary/whitelabeling.ts` | 22 | feature gate |
+
+**`enterpriseProcedure`** (`apps/dokploy/server/api/trpc.ts:216`) gates the `sso`,
+`scim`, `custom-role`, `forward-auth`, `settings`, and `whitelabeling` routers.
+
+**Remote calls** — `apps/dokploy/server/utils/enterprise.ts` (validate/activate/
+deactivate) and `packages/server/src/utils/crons/enterprise.ts` (`LICENSE_KEY_URL`,
+plus a cron every 3 days that sets `isValidEnterpriseLicense = false` when validation
+fails). **Delete the cron early** — leaving it running while removing gates means it
+keeps flipping the flag off underneath you.
+
+**UI** — `apps/dokploy/components/proprietary/enterprise-feature-gate.tsx`,
+`components/proprietary/license-keys/license-key.tsx`,
+`pages/dashboard/settings/license.tsx`, plus the license query in
+`components/dashboard/settings/users/show-users.tsx:40`.
+
+## Procedure
+
+### Step 1 — Collapse the predicate (one small, revertible commit)
+
+Make `hasValidLicense` return `true` unconditionally. Do **not** delete call sites yet.
+
+This makes the whole change one line to revert while you verify behavior. Deleting
+dead branches is a separate commit precisely because it is the irreversible half.
+
+### Step 2 — ⚠️ Handle the access-control call sites
+
+**`getAccessibleServerIds` — `packages/server/src/services/server.ts:183`**
+
+```ts
+const licensed = await hasValidLicense(activeOrganizationId);
+if (!licensed) {
+  return new Set(allOrgServers.map((s) => s.serverId));  // unlicensed: EVERY server
+}
+return new Set(memberRecord?.accessedServers ?? []);      // licensed: only assigned
+```
+
+Forcing `licensed = true` restricts non-admin members to `accessedServers`. On an
+instance that ran unlicensed, that column is almost certainly empty for everyone — so
+**every member-role user abruptly sees zero servers.**
+
+**Required mitigation:** backfill `accessedServers` with all current org servers for
+every existing member *before* the flag flips. That preserves today's effective access
+exactly while turning the feature on. Ship the backfill as a drizzle migration in the
+same release, not as a manual step someone is supposed to remember.
+
+**`resolveRole` — `packages/server/src/services/permission.ts:47`**
+
+Unlicensed returns `null` for non-static roles, making custom roles inert. Forcing
+`true` activates every row in `organizationRole` at once. Audit that table first: a
+half-configured role that was never live becomes live.
+
+**`getAccessibleGitProviderIds` — `packages/server/src/services/git-provider.ts:105`**
+
+Licensed is the wider branch here (adds assigned providers on top of owned + shared).
+Only widens access — low risk, but note it in the PR.
+
+### Step 3 — Verify before deleting anything
+
+- Log in as a **member-role** user. Confirm the visible server list is identical to
+  before. This is the check that catches the step-2 trap.
+- Open white-label settings, SSO, SCIM, custom roles, audit log, forward-auth — all
+  reachable, no "Valid enterprise license required".
+- Confirm no outbound request to `licenses-api.dokploy.com`.
+
+### Step 4 — Delete the dead code
+
+Only once step 3 is green:
+
+- `enterpriseProcedure` → make it a plain authenticated+role check (keep the
+  `owner`/`admin` requirement — that is authorization, not licensing), or replace its
+  usages with `protectedProcedure` where the role check is redundant.
+- Remove the `if (!licensed)` branches at all 14 sites.
+- Delete `apps/dokploy/server/utils/enterprise.ts`,
+  `packages/server/src/utils/crons/enterprise.ts`, and the
+  `initEnterpriseBackupCronJobs()` call in `apps/dokploy/server/server.ts:70`.
+- Delete `apps/dokploy/server/api/routers/proprietary/license-key.ts` and unregister it
+  from `apps/dokploy/server/api/root.ts`.
+- Delete the license UI (above), and the `IS_CLOUD` whitelabeling blocks if cloud
+  should support it too.
+- Drop `hasValidLicense` and `hasAnyValidLicense`.
+
+Search for stragglers:
+
+```bash
+grep -rn "hasValidLicense\|enterpriseProcedure\|isValidEnterpriseLicense\|enableEnterpriseFeatures\|LICENSE_KEY_URL" \
+  --include="*.ts" --include="*.tsx" apps packages
+```
+
+Also check `packages/server/src/lib/auth.ts` (429–454, 590–591, 640–643) where the two
+flags are threaded through the better-auth session, and
+`apps/dokploy/server/api/routers/proprietary/sso.ts:32-45` which reads them directly
+rather than through `hasValidLicense`.
+
+### Step 5 — Database columns, later
+
+Leave `enableEnterpriseFeatures` and `isValidEnterpriseLicense` in place for **at least
+one release** after the gates come out. Dropping them destroys the license state and
+makes rollback impossible. Schedule the drop as its own migration afterwards.
+
+## Tests
+
+`apps/dokploy/__test__/permissions/` covers `resolveRole` and permission resolution and
+will need updating — several tests assert the *unlicensed* fallback. Do not delete a
+failing assertion to make the suite pass; change it to assert the new intended behavior,
+and make sure it still fails when the source is broken on purpose.
+
+## Report
+
+State explicitly whether the step-2 backfill shipped, and what a member-role user sees
+before vs after. That is the finding that matters most to whoever deploys this.

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,18 @@
+# Fork maintenance — see docs/FORK-STRATEGY.md
+#
+# Generated artifacts: keep ours on conflict, then REGENERATE deliberately.
+# Requires (once per clone):  git config merge.ours.driver true
+
+bun.lock                     merge=ours linguist-generated=true
+openapi.json                 merge=ours linguist-generated=true
+
+# Drizzle snapshots are generated; the migration SQL next to them is NOT.
+# `merge=ours` here keeps our snapshot and drops upstream's, which is correct for
+# the snapshot but silently wrong if upstream added migrations. After every
+# upstream sync, review apps/dokploy/drizzle/*.sql by hand and renumber any new
+# upstream migrations into our journal.
+apps/dokploy/drizzle/meta/** merge=ours linguist-generated=true
+
+# Regenerate after a sync:
+#   bun install
+#   bun run generate:openapi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,163 @@
+# Dokploy — project rules
+
+Self-hosted PaaS. TypeScript monorepo, migrating from Node/pnpm to **Bun**.
+This is a **fork** of `Dokploy/dokploy` that still absorbs upstream updates.
+
+> **Migration in progress.** See [docs/bun-migration/PLAN.md](docs/bun-migration/PLAN.md).
+> Until a phase has landed, parts of the repo still use the old toolchain. Check
+> what the file in front of you actually does before assuming either state — do
+> not "fix" a file to Bun conventions as a drive-by if its phase has not landed.
+
+**Branch names:** [docs/BRANCHING.md](docs/BRANCHING.md) — `<type>/<slug>`, e.g.
+`feat/wildcard-domains`. **Fork rules:** [docs/FORK-STRATEGY.md](docs/FORK-STRATEGY.md).
+
+## Fork discipline — read before any wide edit
+
+Upstream still ships, and we still merge it. That makes broad edits expensive in a way
+that is invisible at the time you make them.
+
+- **Never mass-rename or reformat.** 590 files mention "dokploy". A repo-wide rename
+  makes every future upstream merge conflict in every file touched, permanently.
+- **Never reformat an upstream file you are not otherwise changing** — a whitespace-only
+  diff is invisible to you and fatal to `git merge`.
+- **Diverge in files we own**, not by editing upstream logic in place. Prefer changing
+  one constant or one export over rewriting a function.
+- **Never push to the `upstream` remote.** Its push URL is set to `DISABLED` deliberately.
+
+---
+
+## Layout
+
+| Path | What | Runtime |
+|---|---|---|
+| `apps/dokploy` | Next 16 web app (**pages router**) + custom server + 6 WebSocket servers | Bun |
+| `apps/api` | Hono HTTP API | Bun |
+| `apps/schedules` | Hono + BullMQ scheduler | Bun |
+| `packages/server` | Shared domain logic, drizzle schema, docker/ssh/traefik utils | source-only, no build |
+| `apps/monitoring` | **Go service — not part of the Bun migration, do not touch** | Go |
+
+`packages/server` is consumed **as TypeScript source**. It has no build step and no `dist/`.
+Never reintroduce one, and never write a script that mutates its `package.json`
+`exports` (that hack was deliberately deleted — see PLAN §6.2).
+
+---
+
+## Toolchain
+
+**Use Bun for everything.** Never `npm`, `pnpm`, `yarn`, `node`, `tsx`, or `npx`.
+
+| Task | Command |
+|---|---|
+| install | `bun install` |
+| add a dep | `bun add <pkg>` (`-d` for dev) |
+| run a script | `bun run <script>` |
+| one package | `bun run --filter <pkg> <script>` |
+| all packages | `bun run --filter '*' <script>` |
+| run a TS file | `bun file.ts` — never `tsx`, never a build step first |
+| bundle | `bun build` — never esbuild |
+| typecheck | `bun run --filter '*' typecheck` (`tsc --noEmit`) |
+| format / lint | `bun run format-and-lint` (biome) |
+| tests | `bun run test` (vitest) — see Tests below |
+
+**`bun build` does not typecheck.** A green build says nothing about types. Run
+`typecheck` separately, always, before claiming a change compiles.
+
+### Native dependencies
+
+`node-pty`, `ssh2`, `bcrypt`, `better-sqlite3`, `sharp` and friends need postinstall
+scripts. Bun only runs those for packages listed in root `package.json`
+**`trustedDependencies`**. Adding a native dep without adding it there produces a
+package that installs fine and fails at runtime. Add it in the same commit.
+
+---
+
+## Bun APIs
+
+Prefer native Bun over the library it replaces:
+
+- `Bun.serve` / `export default { fetch }` — not `@hono/node-server`
+- `Bun.sql` + `drizzle-orm/bun-sql` — not `postgres.js`
+- `Bun.spawn({ terminal: {...} })` — **not `node-pty`**, which is broken under Bun
+  (PTY dies ~8ms after spawn, `resize()` throws `EBADF`). Note the callbacks take the
+  `Terminal` as their first argument: `data(terminal, chunk)`, not `data(chunk)`.
+- `Bun.file(p).text()` / `Bun.write()` — over `fs.readFile` / `writeFile` on hot paths
+- Bun auto-loads `.env`. Never `import "dotenv/config"`, never `-r dotenv/config`.
+- `fetch` is native. No `undici`.
+
+### Two hard rules
+
+**1. Password hashing must pass `algorithm: "bcrypt"`.**
+
+```ts
+Bun.password.hash(pw, { algorithm: "bcrypt", cost: 10 })   // ✅
+Bun.password.hash(pw)                                       // ❌ defaults to argon2id
+```
+
+Bun's default is argon2id. The `user` table holds `$2b$` bcrypt hashes and
+`packages/server/src/utils/traefik/security.ts` writes an htpasswd file that Traefik
+parses as bcrypt. Defaulting here breaks logins and basic auth. Verified compatible
+in both directions with the npm `bcrypt` package — see PLAN §2.
+
+**2. Do not replace `execAsync` with `Bun.$`.**
+
+`packages/server/src/utils/process/execAsync.ts` runs **pre-assembled command
+strings** and also dispatches to `ssh2` for remote execution. `Bun.$` is a tagged
+template that escapes interpolations; feeding it raw strings needs `.raw` or
+`sh -c`, which reopens the shell-injection surface for no measurable gain. Bun already
+implements `node:child_process` natively. Leave it alone.
+
+---
+
+## Tests
+
+Vitest today, migrating to `bun test` **gradually**, directory by directory
+(PLAN §13). Both runners are green in CI during the transition.
+
+- New tests: write for `bun test`.
+- Existing tests: leave on vitest unless you are deliberately porting that directory.
+
+When porting, `vi.mock` → `mock.module` is **not** a rename. `vi.mock` is hoisted
+above imports; `mock.module` is not, so a module already imported at the top of the
+file will not be replaced — and the test then passes while asserting nothing.
+
+**A port is not done until you have broken the source on purpose and watched the
+test fail.**
+
+---
+
+## Enterprise licensing — being removed
+
+All enterprise features are being unlocked (PLAN §12,
+`.claude/skills/remove-enterprise-license/SKILL.md`). Do not add new license gates.
+
+`hasValidLicense` is **not** purely a feature flag. Three call sites use it to select
+between different access-control behaviors, and in one of them *unlicensed is the more
+permissive branch*:
+
+- `services/server.ts:183` `getAccessibleServerIds` — unlicensed returns **every** org
+  server; licensed returns only `accessedServers`. Forcing licensed **restricts**
+  members and needs a backfill first.
+- `services/permission.ts:47` `resolveRole` — unlicensed makes custom roles inert.
+- `services/git-provider.ts:105` — licensed is the wider branch here.
+
+Read PLAN §12.3 before changing any of these three.
+
+---
+
+## Conventions
+
+- Biome, tabs, double quotes. Run `bun run check` before finishing.
+- `apps/dokploy` is the **pages router**. Not app router. Do not add `app/` routes.
+- tRPC v11 + drizzle + better-auth. Routers live in `apps/dokploy/server/api/routers/`;
+  `proprietary/` holds the formerly-licensed ones.
+- Drizzle migrations are generated, never hand-written:
+  `bun run --filter dokploy migration:generate`.
+- Never edit `openapi.json` by hand — it is generated by `generate:openapi`.
+
+## Don't
+
+- Don't touch `apps/monitoring` (Go).
+- Don't add a build step to `packages/server`.
+- Don't commit `pnpm-lock.yaml`, `pnpm-workspace.yaml`, or `.nvmrc` — they are being deleted.
+- Don't drop the `enableEnterpriseFeatures` / `isValidEnterpriseLicense` columns yet;
+  keep them one release past the gate removal (PLAN §16).

--- a/docs/BRANCHING.md
+++ b/docs/BRANCHING.md
@@ -1,0 +1,80 @@
+# Branch naming convention
+
+One branch = one PR = one coherent change.
+
+## Format
+
+```
+<type>/<slug>
+<type>/<issue>-<slug>      # when an issue exists
+```
+
+Lowercase ASCII, kebab-case. The only `/` is the one after `<type>`. Keep the whole
+name at or under 60 characters.
+
+```
+✅ feat/custom-domain-wildcards
+✅ fix/2451-terminal-resize-desync
+✅ chore/bun-migration
+✅ upstream/sync-v0.31.0
+
+❌ Feature/AddThing          uppercase, wrong type
+❌ sasha/my-branch           personal names
+❌ fix/bug                   says nothing
+❌ feat/add-new-feature-for-the-dashboard-that-does-things   too long
+❌ fix/terminal/resize       second slash
+```
+
+## Types
+
+| Type | Use for |
+|---|---|
+| `feat/` | new user-visible functionality |
+| `fix/` | bug fix |
+| `refactor/` | restructuring with no behavior change |
+| `perf/` | performance work |
+| `chore/` | dependencies, tooling, config, migrations |
+| `ci/` | pipelines and workflows |
+| `docs/` | documentation only |
+| `test/` | tests only |
+| `hotfix/` | urgent production fix, branched from `main` |
+| `release/` | release preparation, e.g. `release/v0.31.0` |
+| `upstream/` | **reserved** — importing or merging upstream Dokploy changes |
+
+`upstream/` is never used for our own work. Seeing it in a PR title means the diff is
+mostly someone else's code and should be reviewed as an integration, not as a change —
+see [FORK-STRATEGY.md](FORK-STRATEGY.md).
+
+## Base branches
+
+Inherited from the upstream project, unchanged:
+
+- **`canary`** — default branch. All normal work targets this.
+- **`main`** — stable. Only `hotfix/` and `release/` branches target it.
+- **`vendor/upstream`** — protected mirror of upstream. Never commit here, never
+  branch feature work from it.
+
+## Rules
+
+- Branch from the branch you will target. `feat/*` from `canary`, `hotfix/*` from `main`.
+- Delete the branch after merge.
+- Rebase or merge `canary` into a long-lived branch rather than letting it drift.
+- Never force-push a branch someone else may have pulled.
+- Never push to `upstream` — the remote's push URL is set to `DISABLED` on purpose.
+  If that ever fails, stop and re-read [FORK-STRATEGY.md](FORK-STRATEGY.md).
+
+## Commits
+
+Conventional Commits, matching the branch type:
+
+```
+feat: add wildcard domain support
+fix(terminal): sync PTY size with frontend
+chore(deps): migrate from pnpm to bun
+```
+
+For upstream integrations, say what was pulled in:
+
+```
+chore(upstream): merge Dokploy v0.31.0
+```

--- a/docs/FORK-STRATEGY.md
+++ b/docs/FORK-STRATEGY.md
@@ -1,0 +1,278 @@
+# Fork strategy — owning this codebase while still absorbing upstream
+
+## Why this fork exists
+
+Not a hostile fork. Upstream's author is reluctant to move Dokploy to Bun — a reasonable
+position for someone responsible for other people's production deployments. This fork
+exists to **find out whether that fear is justified, and to produce evidence either way**.
+
+That purpose changes what "good" looks like here in three ways:
+
+**Evidence is the deliverable.** Benchmarks, spike results, and a record of what broke
+matter more than the diff itself. See [bun-migration/SPIKE-RESULTS.md](bun-migration/SPIKE-RESULTS.md).
+
+**Honesty about failures is the argument, not a weakness in it.** "Everything works out
+of the box" is not persuasive to a careful maintainer — he will find the one thing that
+does not and stop listening. "`node-pty` dies 8ms after spawn under Bun, reproduced on
+macOS and Linux with Node as a control, and here is the native `Bun.Terminal` replacement
+that passes the identical test" is persuasive, because it shows the work was done by
+someone looking for problems rather than around them. Keep the failure register current
+and prominent.
+
+**The ideal outcome is upstream taking this work, not permanent divergence.** So the
+migration is structured as small, independently reviewable phases against upstream's
+existing structure — one phase, one PR — and the de-licensing track is kept in
+**separate branches from the Bun work**. Upstream will never merge a change that removes
+their licensing; entangling the two commits makes the Bun migration unofferable.
+
+## The maintenance tension
+
+Two goals that pull against each other:
+
+1. **This is ours.** Our identity, our decisions, our release cadence.
+2. **Upstream updates still land cleanly.** Dokploy keeps shipping; we want their fixes.
+
+The instinct is to rebrand everything and be done. That is exactly the move that
+destroys goal 2. **590 files in this repo mention "dokploy".** Renaming them turns every
+future merge into a conflict in every file we touched, forever, and the cost compounds
+with each upstream release.
+
+The resolution is not *how much* you diverge but **where**. Diverge in a small number of
+files you fully own; leave everything else byte-identical to upstream so git can merge it
+without asking.
+
+---
+
+## The four rules
+
+### 1. Never mass-edit an upstream file
+
+No repo-wide renames. No reformatting. No import reordering. No "while I'm here"
+cleanups. Every line you change in a file upstream also changes is a future conflict you
+volunteered for.
+
+This includes formatting: do not point a differently-configured Biome at upstream files.
+A whitespace-only reformat is invisible to you and catastrophic to `git merge`.
+
+### 2. Diverge in files you own outright
+
+New behavior goes in new files, in directories upstream does not use. Then the merge is
+"upstream added files, we added files" — which git resolves silently.
+
+When you must change upstream behavior, prefer the smallest possible hook: change one
+constant, one export, one config value, rather than editing the logic in place.
+
+### 3. Centralize identity behind constants
+
+Do **not** find-and-replace "Dokploy" across 590 files. Instead put the strings in one
+module and reference it. Then rebranding is a one-file change, and upstream's 590 files
+stay mergeable.
+
+Values that carry identity and are worth centralizing:
+
+- product name, description, support/docs URLs, meta titles
+- the `/etc/dokploy` base path (`packages/server/src/constants/index.ts:99`)
+- the `dokploy-network` overlay network name
+- the `dokploy/dokploy` Docker image name
+- the license-server URL (removed entirely by the de-licensing track)
+
+⚠️ **The infra names are not cosmetic.** `/etc/dokploy` and `dokploy-network` exist on
+every deployed host and inside running containers. Renaming them is a **data and
+downtime migration**, not a rebrand — existing installs have state at those paths and
+containers attached to that network. Change them only with a migration path, or leave
+them alone and rebrand only what users see.
+
+### 4. Generated files get merge drivers, not merge conflicts
+
+`bun.lock`, `openapi.json`, and drizzle snapshots conflict constantly and are never
+worth hand-merging. Regenerate them instead — see `.gitattributes` below.
+
+---
+
+## The `/proprietary` problem
+
+`LICENSE.MD` splits this repo in two:
+
+- Everything **outside** `/proprietary` directories: **Apache-2.0**. Fork it, rebrand it,
+  redistribute it, sell it. No constraints that matter here.
+- Everything **inside** a `/proprietary` directory: **DSAL 1.0** (`LICENSE_PROPRIETARY.md`).
+
+Three such directories exist:
+
+```
+apps/dokploy/components/proprietary
+apps/dokploy/server/api/routers/proprietary
+packages/server/src/services/proprietary
+```
+
+The DSAL grants copying and modification **for development and testing**, and withholds
+the rest. Its plain text: production use requires *"a valid commercial agreement from
+Dokploy"*, and it is *"forbidden to copy, merge, publish, distribute, sublicense, and/or
+sell the Software."*
+
+**Status: terms for this fork are settled separately with upstream.** On that basis the
+fork keeps the proprietary code and proceeds with the de-licensing track
+([PLAN.md §12](bun-migration/PLAN.md)).
+
+Anyone reading this repository sees only the DSAL text, which says something narrower.
+If that gap ever needs to be visible — for a contributor, a deployment review, or a
+downstream user — the place to record it is a `LICENSE_EXCEPTION.md` written with
+upstream's agreement, not this document.
+
+### What it would take to remove it instead
+
+Recorded because the option was considered and the cost turned out to be much higher
+than a first look suggests. **Not the current plan.**
+
+It is 30 files and **7,770 lines**, not the ~2,000 a top-level file listing implies —
+the UI subdirectories carry 5,725 of them:
+
+| Area | Lines |
+|---|---|
+| SSO (OIDC, SAML, SCIM, forward-auth) | ~2,900 |
+| Custom roles / RBAC | ~1,500 |
+| Audit log | ~900 |
+| White-labeling | ~750 |
+| License key | ~540 |
+| Social sign-in + signup showcase | ~320 |
+
+And the coupling is deep rather than peripheral — **25 non-proprietary files** import
+from these directories, including `packages/server/src/index.ts` (the barrel export),
+`lib/auth.ts`, `services/permission.ts`, `services/server.ts`, `services/git-provider.ts`,
+`apps/dokploy/server/api/root.ts`, and the app shell (`pages/_app.tsx`, `index.tsx`,
+`register.tsx`).
+
+Deleting the directories does not remove a feature module; it breaks authentication,
+permission resolution, and access control. Any removal would be a refactor of the core,
+not a deletion.
+
+Note also that the `/proprietary` boundary is a **directory convention, not a functional
+one**. `auth/sign-in-with-github.tsx` is a plain better-auth OAuth call with nothing
+enterprise about it, and `services/proprietary/sso.ts` mixes real SSO logic with generic
+helpers (`requestToHeaders`, `normalizeTrustedOrigin`, `getOrganizationOwnerId` — the
+last of which `hasValidLicense` depends on). Anyone reasoning about "the proprietary
+part" as a clean unit will be wrong.
+
+*This is a plain reading of the license text, not legal advice.*
+
+---
+
+## Git topology
+
+```
+upstream  https://github.com/Dokploy/dokploy.git   (fetch only, push = DISABLED)
+origin    https://github.com/SashaGoncharov19/dokploy-bun.git
+```
+
+Branches:
+
+| Branch | Role |
+|---|---|
+| `vendor/upstream` | Pristine mirror of `upstream/canary`. **Never commit here.** |
+| `canary` | Our default. All normal work merges here. |
+| `main` | Our stable line. |
+| `upstream/sync-<version>` | Short-lived integration branch for one upstream merge. |
+
+`vendor/upstream` exists so upstream's history enters our repo through exactly one door.
+It makes "what did upstream actually change?" a single readable diff instead of an
+archaeology exercise.
+
+The push URL for `upstream` is deliberately set to `DISABLED`. Nothing we do should ever
+write to Dokploy's repository, and a broken push is a much better outcome than a
+successful one.
+
+### One-time setup
+
+```bash
+git remote add upstream https://github.com/Dokploy/dokploy.git
+git remote set-url --push upstream DISABLED
+git fetch upstream --tags
+git branch vendor/upstream upstream/canary
+```
+
+---
+
+## Absorbing an upstream release
+
+```bash
+# 1. refresh the mirror — fast-forward only, it must never diverge
+git fetch upstream --tags
+git checkout vendor/upstream
+git merge --ff-only upstream/canary
+
+# 2. see what actually changed before merging anything
+git log --oneline canary..vendor/upstream
+git diff --stat canary..vendor/upstream
+
+# 3. integrate on a throwaway branch, never directly on canary
+git checkout canary
+git checkout -b upstream/sync-v0.31.0
+git merge vendor/upstream
+
+# 4. resolve, regenerate, verify
+bun install                      # regenerate bun.lock rather than merging it
+bun run --filter '*' typecheck
+bun run test
+
+# 5. PR into canary
+```
+
+**Never merge upstream straight into `canary`.** The sync branch is what makes a bad
+merge abandonable.
+
+### When conflicts cluster
+
+Conflicts concentrating in the same files every release is a signal, not bad luck — it
+means we diverged in a file upstream actively develops. Fix the *shape*: move our change
+into a file we own and reduce the upstream file to a hook. Ten minutes of that saves the
+same conflict every release thereafter.
+
+---
+
+## `.gitattributes`
+
+Generated artifacts should be regenerated on conflict, never hand-merged:
+
+```gitattributes
+bun.lock            merge=ours linguist-generated=true
+openapi.json        merge=ours linguist-generated=true
+apps/dokploy/drizzle/meta/**  merge=ours linguist-generated=true
+```
+
+`merge=ours` needs the driver registered once per clone:
+
+```bash
+git config merge.ours.driver true
+```
+
+Then regenerate deliberately after every sync: `bun install`,
+`bun run generate:openapi`.
+
+⚠️ **Drizzle migrations are the exception that will bite.** `merge=ours` on
+`drizzle/meta/**` keeps *our* snapshot and discards upstream's — which is right for the
+snapshot but **not** for the migration SQL. If upstream added migrations, those `.sql`
+files must be taken and renumbered, or the schema silently diverges from the journal.
+Always review `apps/dokploy/drizzle/*.sql` by hand during a sync.
+
+---
+
+## What "ours" should mean
+
+Ranked by value-per-unit-of-merge-pain:
+
+| Change | Merge cost | Verdict |
+|---|---|---|
+| Own Docker images, registry, release cadence | none | **do it** |
+| Own CI/CD workflows | low — upstream rarely touches ours | **do it** |
+| Own docs, README, issue templates | none | **do it** |
+| Product name/branding behind constants | low | **do it** |
+| Unlock `/proprietary` features (permission granted) | low — gates only | **doing it** |
+| Rewriting `/proprietary` from scratch | very high — 7,770 lines, 25 coupled files | **not needed** |
+| Bun toolchain migration | moderate, one-time | **doing it** |
+| Renaming `/etc/dokploy`, `dokploy-network` | high + data migration | **only with a migration** |
+| Renaming npm packages (`@dokploy/server`) | high — touches every import | **not worth it** |
+| Repo-wide "dokploy" → new name | catastrophic — 590 files | **never** |
+
+The last row is the one worth internalizing. A fork stays healthy by being *boringly
+similar* to upstream everywhere it does not care, so it can be aggressively different
+in the few places it does.

--- a/docs/bun-migration/PLAN.md
+++ b/docs/bun-migration/PLAN.md
@@ -1,0 +1,581 @@
+# Dokploy → Bun Migration Plan
+
+**Target runtime:** Bun 1.3.14+ (currently installed: 1.3.14)
+**Replaces:** Node.js 24.4.0 + pnpm 10.22.0 + tsx + esbuild
+**Branching:** one phase, one branch, one PR — see [../BRANCHING.md](../BRANCHING.md)
+
+---
+
+## 1. Scope and decisions
+
+Four decisions were made up front and drive everything below.
+
+| # | Decision | Choice |
+|---|----------|--------|
+| 1 | License removal scope | **All enterprise features** — remove licensing entirely, not just white-label |
+| 2 | Next.js runtime | **Everything on Bun**, including `next build` and the custom server |
+| 3 | Native API depth | **Maximum native Bun** — `Bun.serve`, `Bun.sql`, `Bun.password`, `Bun.file` |
+| 4 | Test runner | **Gradual** — vitest keeps running under Bun, port to `bun test` directory by directory |
+
+### In scope
+
+| Package | Language | Current toolchain | Target |
+|---------|----------|-------------------|--------|
+| `packages/server` | TypeScript | tsc + esbuild + tsc-alias | Bun (source-resolved, no build) |
+| `apps/dokploy` | TypeScript, Next 16 pages router | esbuild + `next build --webpack` | `bun build` + `next build` on Bun |
+| `apps/api` | TypeScript, Hono | tsx + tsc | `Bun.serve` via `hono/bun` |
+| `apps/schedules` | TypeScript, Hono + BullMQ | tsx + tsc | `Bun.serve` via `hono/bun` |
+
+### Out of scope
+
+- **`apps/monitoring`** — a Go service (`go.mod`, `main.go`). Untouched. Its `Dockerfile.monitoring` and `.github/workflows/monitoring.yml` stay as they are.
+- **Database schema** — no schema changes required by the Bun migration itself. The de-licensing track has one optional backfill (§8.3).
+
+### Codebase size (from the code graph)
+
+1183 files parsed · 5723 nodes · 70934 edges · 483 flows · 18 communities.
+96 vitest test files, 58 of which use `vi.mock`. 5 Dockerfiles. 9 CI workflows.
+
+---
+
+## 2. Verified facts
+
+These were tested against real Bun 1.3.14 on this machine, not assumed. They are the load-bearing assumptions of the plan.
+
+### ✅ `drizzle-orm/bun-sql` ships in the pinned version
+
+`drizzle-orm@0.45.2` was installed and inspected: the `bun-sql` (and `bun-sqlite`) driver entrypoints are present. **No drizzle upgrade is needed** to move onto `Bun.sql`.
+
+### ✅ bcrypt hashes are bidirectionally compatible with `Bun.password`
+
+This is the single riskiest item in the "max native" path — getting it wrong locks every user out of their account. It was tested both directions:
+
+```
+npm bcrypt hash prefix:       $2b$10$
+Bun.password.verify(npm hash): true    ← existing DB hashes verify under Bun
+bcrypt.compare(bun hash):      true    ← Bun-written hashes verify under npm bcrypt
+wrong password vs npm hash:    false   ← negative case behaves
+```
+
+**Consequences:**
+- **No password migration or forced reset is needed.** Every existing `$2b$` hash in the `user` table keeps working.
+- **The change is reversible.** Because npm `bcrypt` reads Bun-written hashes, a rollback to Node does not strand users who changed their password post-migration.
+- `Bun.password.hash(pw, { algorithm: "bcrypt", cost: 10 })` must be used explicitly. Bun's **default algorithm is argon2id** (`$argon2id$`), which npm `bcrypt` cannot read — defaulting here would be a one-way door.
+
+### ⚠️ `redis` and `ioredis` look like dead dependencies
+
+`apps/dokploy/server/queues/in-memory-queue.ts` states it "replaces BullMQ/Redis for deployments". A grep for `ioredis` / `redis` client imports across `apps/*/src` and `apps/dokploy/server` found **no live import** — the only hit is a code comment in `apps/api/src/index.ts:104`.
+
+`redis@4.7.0` (apps/api) and `ioredis@5.4.1` (apps/schedules) are therefore **candidates for deletion, not migration to `Bun.redis`**. Confirm `bullmq` does not pull `ioredis` in at runtime in `apps/schedules` before removing (§7).
+
+---
+
+## 3. Risk register
+
+Ordered by expected pain. Each has an owner phase and a stated abort condition.
+
+| Risk | Impact | Phase | Abort condition |
+|------|--------|-------|-----------------|
+| **Next.js 16 on Bun** — Next does not officially support Bun as a runtime | Web app fails to build or serve | 5 | `next build` fails or SSR errors that do not reproduce under Node |
+| ~~**`node-pty` under Bun**~~ — **RESOLVED**, see SPIKE-RESULTS | — | 5 | Replaced by native `Bun.Terminal`; node-pty is removed, not fixed |
+| ~~**`ssh2` under Bun**~~ — **CLEARED**, passes fully | — | — | Verified against a real sshd: handshake, exec, stream, shell channel |
+| **License removal changes permission semantics** | Members silently lose or gain access to servers | 8 | See §8.3 — this is a behavioral change, not a no-op |
+| **`vi.mock` → `mock.module` semantics differ** | Tests pass while asserting nothing | 9 | Deliberately break source, confirm the test fails |
+| **`bun install` resolves a different tree than pnpm** | Subtle version drift across 1000+ transitive deps | 1 | Diff the resolved trees before trusting the lockfile |
+
+### Native module gate — ✅ RESOLVED, see [SPIKE-RESULTS.md](SPIKE-RESULTS.md)
+
+`node-pty`, `ssh2`, and `bcrypt` were the load-bearing native dependencies. All are now cleared: **`ssh2`** and **`dockerode`** pass fully under Bun (verified against a real sshd container and the Docker socket); **`bcrypt`** is replaced by `Bun.password`, hash-compatible in both directions (§2); **`node-pty`** does *not* work under Bun (PTY dies ~8ms after spawn, `resize()` throws `EBADF`, on macOS *and* Linux) and is **replaced by the native `Bun.Terminal` API**, which passes the identical test on both platforms — see §9.0. Decision #2 ("everything on Bun, including Next.js") therefore stands, and the migration *removes* a native dependency rather than working around it.
+
+Usage sites:
+- `node-pty` — `apps/dokploy/server/wss/docker-container-terminal.ts`, `docker-container-logs.ts`
+- `ssh2` — `apps/dokploy/server/wss/{terminal,listen-deployment,docker-container-terminal,docker-container-logs}.ts`, `packages/server/src/setup/{server-validate,server-setup,server-audit}.ts`, `packages/server/src/utils/{builders/drop,filesystem/ssh,process/execAsync}.ts`
+
+---
+
+## 4. Phase 0 — Spike the native modules (blocking gate) — ✅ DONE
+
+Completed 2026-08-17. Full results and evidence: [SPIKE-RESULTS.md](SPIKE-RESULTS.md).
+
+| Module | Result |
+|---|---|
+| `ssh2` | ✅ pass — handshake, exec, stdout stream, interactive shell channel |
+| `dockerode` | ✅ pass — ping, listContainers, log stream, stats |
+| `Bun.Terminal` | ✅ pass on macOS **and** Linux — replaces node-pty |
+| `node-pty` | ❌ fails under Bun — **removed**, see §9.0 |
+
+**Gate outcome: PASSED.** Proceed to Phase 1. The one new work item this creates is the
+`node-pty` → `Bun.Terminal` port (§9.0).
+
+Also capture a **baseline** to measure against, since "faster, better, more compact" is the goal and it needs numbers:
+
+```bash
+# record before any change
+pnpm install --frozen-lockfile   # wall time, node_modules size (du -sh)
+pnpm server:build                # wall time
+pnpm --filter=dokploy run build  # wall time
+pnpm test                        # wall time
+docker build -f Dockerfile .     # wall time, final image size
+```
+
+Write these into `SPIKE-RESULTS.md`. Every later phase reports its delta against this baseline.
+
+---
+
+## 5. Phase 1 — Package manager: pnpm → bun
+
+### 1.1 Workspace definition
+
+`pnpm-workspace.yaml` is currently authoritative. Root `package.json` already has a matching `workspaces` array, so:
+
+- **Delete** `pnpm-workspace.yaml`.
+- Keep `workspaces: ["apps/*", "packages/*"]` in root `package.json`. Note this is broader than the pnpm list — it will now also pick up `apps/monitoring`, which has no `package.json` and is therefore harmlessly ignored by Bun.
+
+### 1.2 Translate pnpm-specific config
+
+Root `package.json` currently carries four pnpm-only blocks. Map them:
+
+| pnpm field | Bun equivalent | Notes |
+|---|---|---|
+| `pnpm.overrides` (`esbuild`, `better-call`, `@better-fetch/fetch`) | `overrides` | Bun reads top-level `overrides`. The `esbuild@0.20.2` pin becomes removable once Phase 3 lands. |
+| `resolutions` (`@types/react`, `@types/react-dom`) | `overrides` | Bun treats `resolutions` as a Yarn alias; consolidate on `overrides` to avoid two sources of truth. |
+| `pnpm.onlyBuiltDependencies` (14 packages) | `trustedDependencies` | **Required** — Bun does not run postinstall scripts unless the package is listed. Missing an entry here is how `bcrypt`/`node-pty`/`better-sqlite3` end up unbuilt and failing at runtime. |
+| `pnpm.peerDependencyRules.ignoreMissing` | *(no equivalent)* | Bun does not fail on missing peers; drop it. |
+
+`trustedDependencies` must carry over all 14: `@scarf/scarf`, `@tree-sitter-grammars/tree-sitter-yaml`, `bcrypt`, `better-sqlite3`, `core-js-pure`, `cpu-features`, `esbuild`, `msgpackr-extract`, `node-pty`, `protobufjs`, `sharp`, `ssh2`, `tree-sitter`, `tree-sitter-json`.
+
+### 1.3 Engines
+
+```json
+"engines": { "bun": ">=1.3.14" }
+```
+
+Drop `node` and `pnpm`. Delete `.nvmrc`, add `.bun-version` containing `1.3.14`.
+
+### ⚠️ 1.3b `@codemirror/view` must be pinned — found the hard way
+
+`bun install` and `pnpm install` **do not resolve this monorepo identically**, and the
+difference breaks the typecheck.
+
+`apps/dokploy` declares `@codemirror/view: ^6.39.15`. `@codemirror/autocomplete@6.20.3`
+declares an exact `@codemirror/view: 6.43.6`. pnpm deduped the app down to **6.43.6**;
+bun resolves the app to the newest match, **6.43.8**, and leaves autocomplete on 6.43.6.
+Two copies of `EditorView` then have "separate declarations of a private property", and
+`components/shared/env-autocomplete.ts` fails to compile with ~20 errors.
+
+Verified by running `tsc --noEmit` under both layouts: **pnpm exit 0, bun exit 1**.
+
+Fix — add to `overrides`, matching what pnpm resolved so behavior is preserved:
+
+```json
+"@codemirror/view": "6.43.6"
+```
+
+After that, a full tree comparison across the 929 packages present in both lockfiles
+found **0 version differences** and **0 packages that were single-version under pnpm but
+multi-version under bun**. Re-run that comparison if the lockfile is ever regenerated
+from scratch.
+
+### 1.4 Install and diff the tree
+
+```bash
+bun install
+```
+
+**Do not trust the new lockfile on sight.** Diff the resolved dependency tree against pnpm's before deleting `pnpm-lock.yaml`:
+
+```bash
+# capture both, compare resolved versions for every package
+bun pm ls --all > /tmp/bun-tree.txt
+```
+
+Pay attention to anything with a native postinstall and to the `esbuild`/`better-call`/`@better-fetch/fetch` pins. Once the tree is confirmed equivalent, delete `pnpm-lock.yaml` and commit `bun.lock`.
+
+### 1.5 Root scripts
+
+Rewrite all `pnpm --filter=X run Y` as `bun run --filter X Y`. `pnpm -r run Y` becomes `bun run --filter '*' Y`.
+
+**Exit criteria:** `bun install` from clean produces a working `node_modules`; `bun run --filter '*' typecheck` passes; `node_modules` size recorded vs baseline.
+
+---
+
+## 6. Phase 2 — Script runner: tsx → bun, and delete the export-swap hack
+
+### 2.1 Replace tsx (14 script references)
+
+Bun executes TypeScript natively. Every `tsx foo.ts` becomes `bun foo.ts`, and every `tsx -r dotenv/config foo.ts` becomes just `bun foo.ts` — **Bun auto-loads `.env`**, so the `dotenv/config` preload is redundant.
+
+Affected scripts in `apps/dokploy/package.json`: `setup`, `dev`, `migration:run`, `manual-migration:run`, `db:truncate`, `db:seed`, `db:clean`, `wait-for-postgres-dev`, `generate:openapi`, `build-server`. Plus `dev` in `apps/api` and `apps/schedules` (`tsx watch` → `bun --watch`).
+
+Remove `tsx` from every `devDependencies`. Also remove the global `pnpm install -g tsx` from `Dockerfile:58`.
+
+### 2.2 Delete the switchToSrc/switchToDist hack — a real simplification
+
+`packages/server` currently ships a pair of scripts (`scripts/switchToSrc.js`, `scripts/switchToDist.js`) that **rewrite `package.json` `main`/`exports` in place** to point at `./src/*.ts` for development and `./dist/*.cjs.js` for production. This exists only because Node cannot import TypeScript from a workspace dependency.
+
+Bun resolves TypeScript source directly across workspace boundaries. Therefore:
+
+- **Delete** `packages/server/scripts/switchToSrc.js` and `switchToDist.js`.
+- **Delete** the `switch:dev` / `switch:prod` scripts, and the root `server:script` script that calls them.
+- **Pin** `packages/server/package.json` permanently to source:
+  ```json
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./db": "./src/db/index.ts",
+    "./setup/*": "./src/setup/*.ts",
+    "./constants": "./src/constants/index.ts"
+  }
+  ```
+  The `require` → `dist/*.cjs.js` conditions go away entirely.
+- **Delete** `packages/server`'s `build`, `dev`, and `esbuild` scripts and its `esbuild.config.ts`. `packages/server` becomes a source-only package with no build step at all.
+
+This removes a build step, a mutable-`package.json` footgun, and a class of "works in dev, breaks in prod" bugs. It also removes `tsc-alias` and `esbuild-plugin-alias` from the dependency tree.
+
+**Exit criteria:** `bun run --filter '*' typecheck` passes with `packages/server` resolved from source; no script mutates `package.json`.
+
+---
+
+## 7. Phase 3 — Bundler: esbuild/tsc → bun build
+
+### 3.1 `apps/dokploy` server bundle
+
+`apps/dokploy/esbuild.config.ts` bundles 6 entrypoints (`server`, `migration`, `wait-for-postgres`, `reset-password`, `reset-2fa`, `migrate-auth-secret`) to `dist/*.mjs`, ESM, minified, `packages: "external"`, with `.env.production` values inlined via `define`.
+
+Replace with `bun build`:
+
+```bash
+bun build ./server/server.ts ./migration.ts ./wait-for-postgres.ts \
+  ./reset-password.ts ./reset-2fa.ts ./scripts/migrate-auth-secret.ts \
+  --target=bun --outdir=dist --minify --sourcemap --packages=external
+```
+
+Two behavioral notes:
+- Output extension becomes `.js`, not `.mjs`. Update `apps/dokploy/package.json` `start` and the Dockerfile `CMD` together, or the container will fail to boot.
+- The `define` block inlining `.env.production` (minus `DATABASE_URL`) can be **dropped entirely** — Bun reads `.env` at runtime, which is what the `DATABASE_URL` exception was already working around. Verify no build-time-only env var is relied upon before removing.
+
+### 3.2 `apps/api` and `apps/schedules`
+
+Both use `rimraf dist && tsc --project tsconfig.json`. Replace with:
+
+```bash
+rm -rf dist && bun build ./src/index.ts --target=bun --outdir=dist --minify --sourcemap --packages=external
+```
+
+Drop `rimraf` from both. Keep a `typecheck` script on `tsc --noEmit` — **`bun build` does not typecheck**, so the type safety net must stay explicit in CI.
+
+### 3.3 Keep tsc for one thing
+
+`packages/server` no longer builds, but `tsc --noEmit` remains the only typechecker. Note the repo pins `typescript@^7.0.2` — the Go-based compiler — which is itself a large typecheck speedup independent of Bun.
+
+**Exit criteria:** all three bundles build; `bun dist/server.js` boots; build wall-times recorded vs baseline.
+
+---
+
+## 8. Phase 4 — Runtime: node → bun
+
+### 4.1 Hono servers → `Bun.serve`
+
+`apps/api/src/index.ts:1` and `apps/schedules/src/index.ts:1` both `import { serve } from "@hono/node-server"`. Hono has first-class Bun support:
+
+```ts
+// before
+import { serve } from "@hono/node-server";
+serve({ fetch: app.fetch, port });
+
+// after — Bun.serve is the default export contract
+export default { port, fetch: app.fetch };
+```
+
+Remove `@hono/node-server` from both packages. This is a straight win: fewer deps, native HTTP.
+
+### 4.2 Next.js custom server
+
+`apps/dokploy/server/server.ts` builds a `node:http` server, hands requests to Next's `getRequestHandler()`, and attaches **six** WebSocket servers to it (drawer-logs, deployment-logs, container-logs, container-terminal, terminal, docker-stats).
+
+Bun implements `node:http`, so the first move is **change nothing but the interpreter** — run the existing file under `bun` and see what breaks. Do not rewrite to `Bun.serve` in the same step; the WebSocket upgrade path is the most fragile part of this migration and it must be isolated from other changes.
+
+Only if `node:http` + `ws` proves unreliable under Bun, migrate the six WS servers to `Bun.serve`'s native `websocket` handler — that is a substantially larger change with its own risk, and it is a fallback, not the plan.
+
+### 4.3 Process entrypoints
+
+Everywhere `node -r dotenv/config dist/X.mjs` appears (package.json `start`, all Dockerfile `CMD`s), it becomes `bun dist/X.js`. The `-r dotenv/config` preload disappears.
+
+**Exit criteria:** `bun run dev` serves the app; all six WebSocket features verified by hand (terminal, container terminal, container logs, deployment logs, drawer logs, docker stats); `bun dist/server.js` boots in production mode.
+
+---
+
+## 9. Phase 5 — Native Bun APIs
+
+Ordered from safest to most invasive. Each is independently revertible.
+
+### 5.0 `Bun.Terminal` replaces `node-pty` — required, not optional
+
+Unlike the rest of this phase, this one is mandatory: `node-pty` does not function under
+Bun (SPIKE-RESULTS). Two files in `apps/dokploy` import it —
+`server/wss/docker-container-terminal.ts` (including `ptyProcess.resize()` at line 199)
+and `server/wss/docker-container-logs.ts`.
+
+```ts
+const proc = Bun.spawn({
+  cmd: [file, ...args],
+  cwd, env,
+  terminal: {
+    cols, rows, name: "xterm-color",
+    data(terminal, chunk) { /* was p.onData */ },
+    exit(terminal, code, signal) { /* was p.onExit */ },
+  },
+});
+proc.terminal.write(input);       // was p.write
+proc.terminal.resize(cols, rows); // was p.resize
+```
+
+**The callbacks take the `Terminal` instance as their first argument** — `data(terminal,
+chunk)`, not `data(chunk)`. Getting this wrong fails confusingly: the chunk silently
+becomes the Terminal object rather than throwing at the call site.
+
+Verify with the same checks the spike used: a sustained multi-command session, `test -t 0`
+inside the child returning true, and `stty size` reflecting a mid-session resize. Then drop
+`node-pty` from `apps/dokploy` dependencies and from root `trustedDependencies`.
+
+### 5.1 `Bun.password` replaces `bcrypt` — verified safe (§2)
+
+Six call sites:
+
+| File | Line | Current | Replacement |
+|---|---|---|---|
+| `packages/server/src/lib/auth.ts` | 151 | `bcrypt.hashSync(password, 10)` | `Bun.password.hashSync(password, { algorithm: "bcrypt", cost: 10 })` |
+| `packages/server/src/lib/auth.ts` | 154 | `bcrypt.compareSync(password, hash)` | `Bun.password.verifySync(password, hash)` |
+| `packages/server/src/services/user.ts` | 468 | `bcrypt.hashSync(password, 10)` | same as above |
+| `packages/server/src/auth/random-password.ts` | 18 | `bcrypt.hash(randomPassword, saltRounds)` | `Bun.password.hash(pw, { algorithm: "bcrypt", cost: saltRounds })` |
+| `packages/server/src/utils/traefik/security.ts` | 37 | `bcrypt.hash(data.password, 10)` | same — **must stay bcrypt**, this writes an htpasswd file Traefik parses |
+| `apps/dokploy/server/api/routers/user.ts` | 237, 258 | `compareSync` / `hashSync` | as above |
+
+**The `algorithm: "bcrypt"` option is mandatory on every hash call.** Bun defaults to argon2id; a hash written as argon2id into the Traefik htpasswd file silently breaks basic auth, and one written to the `user` table cannot be read by a rolled-back Node deployment.
+
+Then remove `bcrypt` and `@types/bcrypt` from both packages, and drop `bcrypt` from `trustedDependencies`.
+
+### 5.2 `Bun.sql` replaces `postgres.js`
+
+Five connection sites: `packages/server/src/db/index.ts:20`, `apps/dokploy/server/db/index.ts:22,28`, `apps/dokploy/migration.ts:6`, `apps/dokploy/server/db/reset.ts:7`.
+
+```ts
+// before
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+drizzle(postgres(dbUrl), { schema });
+
+// after
+import { drizzle } from "drizzle-orm/bun-sql";
+drizzle(dbUrl, { schema });
+```
+
+The migrator import changes too: `drizzle-orm/postgres-js/migrator` → `drizzle-orm/bun-sql/migrator`.
+
+**Do this one behind its own verification.** Connection pooling, prepared statements, and error shapes differ between postgres.js and `Bun.sql`. Specific things to check: the `max: 1` option used in `migration.ts` and `reset.ts` (single-connection migration safety), transaction semantics in the migrator, and the `PostgresJsDatabase` type export which is referenced in two files and must become `BunSQLDatabase`.
+
+Run the **full migration chain against a scratch database** — all 180+ drizzle migrations from empty — before accepting this change. Then drop `postgres` from both packages.
+
+### 5.3 `Bun.file` for filesystem reads
+
+`packages/server` does substantial filesystem work (traefik config, compose files, SSH keys). `Bun.file(path).text()` / `.json()` is faster than `fs.readFile`, and `Bun.write()` replaces `fs.writeFile`. This is a mechanical, low-risk sweep — but it is also the **lowest-value** item here. Do it last, or skip it, and only where a file is genuinely on a hot path. Churning 100 call sites for no measurable win is not a good trade.
+
+### 5.4 `Bun.$` — recommended **against**
+
+The "max native" option nominally includes replacing `execAsync` with `Bun.$`. **I recommend not doing this**, and the plan omits it from the exit criteria.
+
+`packages/server/src/utils/process/execAsync.ts` promisifies `child_process.exec` over **command strings that are assembled elsewhere** — docker CLI invocations, traefik commands, remote shell lines. `Bun.$` is a tagged template that applies its own escaping to interpolated values; feeding it pre-built strings requires `$\`sh -c ${cmd}\`` or `.raw`, which reintroduces exactly the shell-injection surface the template syntax exists to prevent. The same file also dispatches to `ssh2` for remote execution, which `Bun.$` cannot cover at all.
+
+The upside is nil — Bun implements `node:child_process` natively, so `exec` is already running on Bun's own process spawning. **Keep `execAsync` as it is.** If a specific hot path is ever measured to be spawn-bound, revisit it in isolation.
+
+**Exit criteria:** login works with a pre-existing account (proves 5.1); a fresh DB migrates from empty and an existing DB starts clean (proves 5.2).
+
+---
+
+## 10. Phase 6 — Dependency cleanup
+
+Removals enabled by earlier phases. Each needs a grep to confirm no live import before deletion.
+
+| Package | Reason | Enabled by |
+|---|---|---|
+| `tsx` (3 packages) | Bun runs TS natively | Phase 2 |
+| `esbuild` + `esbuild-plugin-alias` | replaced by `bun build` | Phase 3 |
+| `tsc-alias` | no build step in `packages/server` | Phase 2 |
+| `rimraf` (3 packages) | `rm -rf` | Phase 3 |
+| `dotenv` (7 files) | Bun auto-loads `.env` | Phase 2 |
+| `@hono/node-server` (2 packages) | `Bun.serve` | Phase 4 |
+| `bcrypt`, `@types/bcrypt` | `Bun.password` | Phase 5.1 |
+| `postgres` | `Bun.sql` | Phase 5.2 |
+| `undici` | Bun has native `fetch` | — |
+| `redis` (apps/api) | **appears dead** — verify first (§2) | — |
+| `ioredis` (apps/schedules) | **appears dead** — check `bullmq` runtime need first | — |
+
+Also drop the root `esbuild: "0.20.2"` override once nothing depends on esbuild.
+
+**Exit criteria:** `node_modules` size and install time recorded vs baseline. This phase is where the "compact" goal is actually paid out.
+
+---
+
+## 11. Phase 7 — Docker and CI
+
+### 7.1 Dockerfiles
+
+Four of the five need rewriting (`Dockerfile.monitoring` is Go — leave it).
+
+Common changes for `Dockerfile`, `Dockerfile.cloud`, `Dockerfile.server`, `Dockerfile.schedule`:
+
+- `FROM node:24.4.0-slim` → `FROM oven/bun:1.3.14-slim`
+- Delete the `corepack enable` / `corepack prepare pnpm` lines and `PNPM_HOME`/`PATH`
+- `pnpm install --frozen-lockfile` → `bun install --frozen-lockfile`; cache mount id `pnpm` → `bun`, target `/pnpm/store` → `/root/.bun/install/cache`
+- `pnpm --filter=X build` → `bun run --filter X build`
+- **`pnpm deploy --legacy /prod/X` has no Bun equivalent.** This is the one genuinely non-mechanical step: it currently produces a pruned production `node_modules`. Options: (a) `bun install --production` into a fresh stage, or (b) `bun build --compile` to a single executable, which would make the runtime stage dramatically smaller. (b) is the more interesting option for the "compact" goal and is worth spiking for `apps/api` and `apps/schedules` first, where the surface is small.
+- `CMD ["pnpm", "start"]` → `CMD ["bun", "dist/index.js"]`
+- Main `Dockerfile` CMD: `node -r dotenv/config dist/*.mjs` → `bun dist/*.js`, and drop `pnpm install -g tsx` (line 58)
+- The build-tools apt layer (`python3 make g++ pkg-config libsecret-1-dev`) is still needed while `node-pty`/`ssh2` compile from source
+
+`tini` stays — it reaps the HEALTHCHECK children, and that need is unchanged by the runtime swap.
+
+### 7.2 CI (9 workflows)
+
+In `.github/workflows/pull-request.yml` and every other workflow touching Node:
+
+```yaml
+# replace pnpm/action-setup@v5 + actions/setup-node@v5
+- uses: oven-sh/setup-bun@v2
+  with:
+    bun-version: 1.3.14
+- run: bun install --frozen-lockfile
+- run: bun run --filter '*' ${{ matrix.job }}
+```
+
+`pnpm server:build` disappears from CI entirely — `packages/server` has no build step after Phase 2.
+
+`dokploy.yml` uses `node -p "require('./apps/dokploy/package.json').version"` to read the version; `bun -p` works identically, or use `jq`.
+
+**Exit criteria:** green CI on all three matrix jobs; image sizes recorded vs baseline.
+
+---
+
+## 12. Phase 8 — Remove enterprise licensing
+
+This runs **independently of the Bun track** and can be done in parallel or first. See `.claude/skills/remove-enterprise-license/SKILL.md` for the step-by-step procedure.
+
+### 8.1 The surface
+
+`hasValidLicense(organizationId)` — `packages/server/src/services/proprietary/license-key.ts:10` — has **14 call sites**. `enterpriseProcedure` — `apps/dokploy/server/api/trpc.ts:216` — gates the sso, scim, custom-role, forward-auth, settings, and whitelabeling routers.
+
+Backing state is two `user` columns: `enableEnterpriseFeatures` and `isValidEnterpriseLicense`.
+
+Remote calls to `https://licenses-api.dokploy.com` live in `apps/dokploy/server/utils/enterprise.ts` (validate/activate/deactivate) and `packages/server/src/utils/crons/enterprise.ts` (a cron every 3 days that flips `isValidEnterpriseLicense` to false on failure). Both get deleted — **note that the existing cron will actively disable enterprise features if the license server is unreachable**, so leaving it in place while removing the gates would be self-defeating.
+
+### 8.2 Approach
+
+Rather than editing 14 call sites plus every consumer, **collapse the predicate**: make `hasValidLicense` return `true` unconditionally, verify the whole app against that, and only then delete the now-dead branches, the license-key router, the license UI, the cron, and finally the two DB columns. Removing the gate and removing the code are two separate commits — the first is trivially revertible, the second is not.
+
+### 8.3 ⚠️ This is not a no-op — it changes permission semantics
+
+**Flagging this prominently because it can silently break a running instance.** Three of the 14 call sites use the license flag to choose between *different access-control behaviors*, not merely to show or hide a feature:
+
+**`getAccessibleServerIds` (`packages/server/src/services/server.ts:183`) — unlicensed is the _permissive_ branch:**
+```ts
+const licensed = await hasValidLicense(activeOrganizationId);
+if (!licensed) {
+  return new Set(allOrgServers.map((s) => s.serverId));  // ← sees EVERY server
+}
+return new Set(memberRecord?.accessedServers ?? []);      // ← sees only assigned
+```
+Forcing `licensed = true` **restricts** non-admin members to their `accessedServers` list. On an instance that has been running unlicensed, that column is likely empty for everyone — so **every non-admin member would abruptly see zero servers.**
+
+**Recommended mitigation:** ship a one-time backfill that sets `accessedServers` to all current org servers for every existing member, then enable the licensed branch. This preserves today's effective access exactly while turning the feature on. Without the backfill, this is a production outage for member-role users.
+
+**`resolveRole` (`packages/server/src/services/permission.ts:47`)** — unlicensed returns `null` for any non-static role, so custom roles are inert. Forcing `true` makes every stored custom role take effect at once. Audit the `organizationRole` table before enabling: a stale or half-configured custom role that was never active becomes live.
+
+**`getAccessibleGitProviderIds` (`packages/server/src/services/git-provider.ts:105`)** — here licensed is the *more permissive* branch (it adds assigned providers on top of owned + shared), so this one only widens access. Lower risk, but still a change.
+
+The remaining 11 call sites are ordinary feature gates and are safe to force true.
+
+**Exit criteria:** a member-role user sees the same servers before and after; custom roles behave as intended; no outbound request to `licenses-api.dokploy.com` remains.
+
+---
+
+## 13. Phase 9 — Tests (gradual)
+
+Per decision #4, vitest stays and runs under Bun. `bun run test` invokes the existing vitest config unchanged.
+
+Port directory by directory (`__test__/permissions`, `__test__/traefik`, …), smallest first. The mapping:
+
+| vitest | bun:test |
+|---|---|
+| `vi.fn` (129) | `jest.fn` / `mock` |
+| `vi.mock` (58) | `mock.module` — **semantics differ, see below** |
+| `vi.mocked` (36) | type-level, usually deletable |
+| `vi.hoisted` (16) | no equivalent; restructure — `mock.module` is not hoisted |
+| `vi.clearAllMocks` (14) | `jest.clearAllMocks` |
+| `vi.stubEnv` / `unstubAllEnvs` | assign `process.env` directly |
+
+**The `vi.mock` → `mock.module` gap is the whole cost of this phase.** `vi.mock` is hoisted above imports; `mock.module` is not, so a module already imported at the top of the file will not be replaced. Ported files need their import order restructured, and a mock that silently fails to apply produces a **passing test that asserts nothing**.
+
+Guard against that: for each ported file, deliberately break the source it covers and confirm the test actually fails. A port is not done until it has failed on purpose once.
+
+Keep both runners green in CI during the transition — `bun test` over the ported directories, vitest over the rest.
+
+---
+
+## 14. Execution order
+
+```
+Phase 0  Spike node-pty / ssh2 / dockerode + capture baseline   ← BLOCKING GATE
+   │
+   ├─ Phase 8  De-licensing (independent track, can start immediately)
+   │
+Phase 1  pnpm → bun
+Phase 2  tsx → bun, delete switchToSrc/Dist hack
+Phase 3  esbuild/tsc → bun build
+Phase 4  node → bun runtime (incl. Next.js)                     ← HIGHEST RISK
+Phase 5  Native APIs (password → sql → file)
+Phase 6  Dependency cleanup
+Phase 7  Docker + CI
+Phase 9  Tests (continuous, runs alongside 1–7)
+```
+
+Each phase is one PR. Phases 1–4 must land in order; 5 and 6 can interleave; 8 is independent.
+
+---
+
+## 15. Definition of done
+
+**Functional**
+- [ ] `bun install` from clean produces a working tree
+- [ ] `bun run dev` serves the app
+- [ ] All six WebSocket features verified by hand under Bun
+- [ ] Remote server ops (deploy, logs, terminal) verified against a real remote host
+- [ ] A pre-existing user logs in with their existing password
+- [ ] Full drizzle migration chain runs from an empty database
+- [ ] All four Docker images build and boot
+- [ ] CI green on build, test, typecheck
+- [ ] All enterprise features usable with no license; no request to `licenses-api.dokploy.com`
+- [ ] Member-role server visibility unchanged from pre-migration (§8.3 backfill applied)
+
+**Measured** — recorded against the Phase 0 baseline
+- [ ] Install time and `node_modules` size
+- [ ] Build wall-time per package
+- [ ] Test suite wall-time
+- [ ] Docker image size
+- [ ] Server cold-boot time and steady-state RSS
+
+**Removed**
+- [ ] `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `.nvmrc`
+- [ ] `switchToSrc.js`, `switchToDist.js`, both `esbuild.config.ts`
+- [ ] Dependencies listed in §10
+- [ ] License service, cron, router, and UI
+
+---
+
+## 16. Rollback
+
+Every phase is a single PR against `canary` and reverts cleanly. The two changes that are **not** cleanly reversible once users have interacted with them:
+
+- **Phase 5.2 (`Bun.sql`)** — if a migration runs under the new driver, reverting the driver does not revert the schema. Take a database snapshot first.
+- **Phase 8 DB column drop** — dropping `enableEnterpriseFeatures` / `isValidEnterpriseLicense` destroys the license state. Keep the columns for at least one release after the gates come out; drop them in a later cleanup.
+
+Phase 5.1 (`Bun.password`) is reversible — verified in §2.

--- a/docs/bun-migration/SPIKE-RESULTS.md
+++ b/docs/bun-migration/SPIKE-RESULTS.md
@@ -1,0 +1,168 @@
+# Phase 0 — Native module spike results
+
+**Date:** 2026-08-17
+**Bun:** 1.3.14 · **Node control:** 24.x (Linux) / 22.20.0 (macOS)
+**Platforms:** macOS arm64 (dev) and `oven/bun:1.3.14-slim` Debian (production target)
+
+## Verdict: ✅ GATE PASSED — "everything on Bun" is achievable
+
+`node-pty` does not work under Bun, but it does not need to: **Bun ships a native PTY,
+`Bun.Terminal`**, which passes every test node-pty failed. The migration replaces the
+dependency rather than working around it.
+
+| Module | Bun | Node | Result |
+|---|---|---|---|
+| `ssh2` | ✅ | ✅ | **PASS** — handshake, exec channel, stdout stream, interactive shell channel |
+| `dockerode` | ✅ | ✅ | **PASS** — ping, listContainers, log stream, stats |
+| `Bun.Terminal` | ✅ | n/a | **PASS** — replaces node-pty; verified on macOS **and** Linux |
+| `node-pty` | ❌ | ✅ | fails under Bun — **to be removed**, not fixed |
+
+Every test ran the same file against the same `node_modules` and the same compiled
+`.node` binaries, switching only the interpreter. Node is the control where applicable.
+
+---
+
+## `Bun.Terminal` — the replacement for node-pty
+
+Identical test to the one node-pty failed, on both platforms:
+
+```
+                    macOS arm64      Linux (oven/bun:1.3.14-slim)
+exited early    :   false            false
+marker echoed   :   true             true
+resize          :   ok               ok
+resize applied  :   true             true
+child sees tty  :   true             true
+sustained usable:   true             true
+total bytes     :   346              175
+clean exit      :   true             true
+```
+
+`child sees tty` is `test -t 0` inside the spawned shell, and `resize applied` is
+`stty size` reporting `40 120` after a mid-session `resize(120, 40)` — the exact
+behavior `docker-container-terminal.ts:199` depends on.
+
+### API shape (verified by introspection, 1.3.14)
+
+```ts
+const proc = Bun.spawn({
+  cmd: ["/bin/sh"],
+  terminal: {
+    cols: 80,
+    rows: 24,
+    name: "xterm-color",
+    data(terminal, chunk: Uint8Array) { /* output */ },
+    exit(terminal, code, signal) { /* exited */ },
+  },
+});
+proc.terminal.write("echo hi\r");
+proc.terminal.resize(120, 40);
+```
+
+**The callbacks take the `Terminal` instance as their first argument** — `data(terminal,
+chunk)`, not `data(chunk)`. This is easy to get wrong and fails in a confusing way
+(the chunk silently becomes the Terminal object), so it is worth stating in the port.
+
+`proc.terminal` exposes: `write`, `resize`, `setRawMode`, `close`, `closed`, `ref`,
+`unref`, `controlFlags`, `inputFlags`, `localFlags`, `outputFlags`.
+
+Uses `openpty()` on Linux/macOS, ConPTY on Windows (irrelevant here — deploy target is
+Linux).
+
+### Migration work this creates
+
+Two files import `node-pty`, both in `apps/dokploy`:
+
+- `apps/dokploy/server/wss/docker-container-terminal.ts` — including
+  `ptyProcess.resize(...)` at line 199
+- `apps/dokploy/server/wss/docker-container-logs.ts`
+
+Port both from `spawn` (node-pty) to `Bun.spawn` + `terminal`. Mapping:
+
+| node-pty | Bun.Terminal |
+|---|---|
+| `spawn(file, args, { cols, rows, name, cwd, env })` | `Bun.spawn({ cmd: [file, ...args], cwd, env, terminal: { cols, rows, name } })` |
+| `p.onData(cb)` | `terminal.data(terminal, chunk)` callback |
+| `p.onExit(cb)` | `terminal.exit(terminal, code, signal)` callback |
+| `p.write(s)` | `proc.terminal.write(s)` |
+| `p.resize(c, r)` | `proc.terminal.resize(c, r)` |
+| `p.pid` | `proc.pid` |
+
+Then drop `node-pty` from `apps/dokploy` dependencies and from `trustedDependencies`.
+This removes a native module from the tree entirely — a net simplification, and it may
+let the `python3 make g++` layer shrink in the Dockerfiles once `bcrypt` also goes
+(PLAN §9.1). `ssh2` still has optional native pieces, so verify before removing that
+layer outright.
+
+---
+
+## Why node-pty fails under Bun (recorded for completeness)
+
+Not a blocker anymore, but the evidence, since it is why we are replacing it:
+
+```
+### BUN ###                     ### NODE ###
+onExit fired at: 8ms            onExit fired at: not yet
+step A/B/C echoed: false        step A/B/C echoed: true
+total bytes received: 2         total bytes received: 71
+sustained session usable: false sustained session usable: true
+```
+
+The PTY child exits ~8ms after spawn; the two bytes are terminal echo, not command
+output. `resize()` then throws `ioctl(2) failed, EBADF` because the fd is already gone.
+Reproduced identically on macOS arm64 and Debian, so not a platform quirk. This matches
+the known upstream issues ([oven-sh/bun#7362](https://github.com/oven-sh/bun/issues/7362),
+[microsoft/node-pty#632](https://github.com/microsoft/node-pty/issues/632)).
+
+### Secondary finding: `bun install` drops the executable bit
+
+On macOS, `bun add node-pty@1.1.0` extracted the prebuilt helper non-executable
+(`-rw-r--r-- prebuilds/darwin-arm64/spawn-helper`), so `pty.fork()` failed with
+`posix_spawnp failed` before anything else could be tested. `chmod +x` got past it.
+
+This is a **separate Bun packaging bug** from the runtime failure, and it is worth
+remembering beyond node-pty: it would hit **any** dependency shipping a prebuilt
+executable. If a package mysteriously fails to exec its own helper binary after
+`bun install`, check the mode bits first.
+
+Also note node-pty 1.1.0 ships prebuilds only for darwin/win32 — **no Linux prebuild** —
+so Linux compiled it from source via node-gyp. That is why the Dockerfiles install
+`python3 make g++`. Removing node-pty removes that particular reason for the layer.
+
+---
+
+## Baseline and Phase 1 measurements
+
+Captured on this machine (macOS arm64), pnpm 10.22.0 provisioned via corepack.
+
+| Metric | pnpm (before) | bun (after) | Δ |
+|---|---|---|---|
+| `install --frozen-lockfile`, warm cache | **21.9s** | **13.4s** (first, incl. lockfile migration) / **5.5s** (subsequent) | ~1.6×–4× faster |
+| `node_modules` size | **1.5G** | **1.5G** | unchanged |
+| Packages installed | — | 3295 | — |
+| Typecheck, all 4 packages | 0 errors | **0 errors** | parity |
+| Test suite | — | **95/96 files, 869/874 tests pass** | see below |
+| Lockfile size | 671 KB (`pnpm-lock.yaml`) | 503 KB (`bun.lock`) | 25% smaller |
+
+`bun install` migrated `pnpm-lock.yaml` to `bun.lock` automatically on first run.
+
+**Not yet measured:** build wall-times, Docker image sizes, server cold-boot time and
+RSS. Those become meaningful after Phases 3–4 and 7, when the build and runtime actually
+change; measuring them now would only re-measure the Node toolchain.
+
+### Test failures are environmental, not migration-caused
+
+4 tests in `__test__/deploy/application.real.test.ts` fail locally, all with the same
+root cause:
+
+```
+(HTTP code 503) This node is not a swarm manager.
+Use "docker swarm init" or "docker swarm join" ...
+```
+
+CI initializes swarm explicitly before the test job
+(`.github/workflows/pull-request.yml:43`), so these pass there. They were **not** run
+locally under a swarm, so they are unverified rather than known-good — `docker swarm
+init` changes the host Docker daemon globally, which is not something to do
+unilaterally on a dev machine. To close the gap: `docker swarm init && docker network
+create --driver overlay dokploy-network`, re-run, then `docker swarm leave --force`.


### PR DESCRIPTION
Groundwork for the Bun migration and for maintaining this fork alongside upstream Dokploy. Documentation only — no code changes.

## What's here

| File | Purpose |
|---|---|
| `docs/bun-migration/PLAN.md` | 9-phase migration plan, per-phase exit criteria, risk register, rollback notes |
| `docs/bun-migration/SPIKE-RESULTS.md` | Phase 0 native-module gate results and pnpm/bun baseline measurements |
| `docs/FORK-STRATEGY.md` | Why this fork exists, how to stay mergeable with upstream, the `/proprietary` licensing situation |
| `docs/BRANCHING.md` | `<type>/<slug>` branch naming convention |
| `CLAUDE.md` | Project rules, Bun conventions, fork discipline |
| `.gitattributes` | Merge drivers for generated files |
| `.claude/skills/` | Repeatable procedures for the migration and de-licensing |

## Findings worth reading

Everything below was tested against real Bun 1.3.14 with Node as a control, not assumed.

**`node-pty` does not work under Bun.** The PTY child exits ~8ms after spawn and `resize()` throws `EBADF`. Reproduced identically on macOS arm64 and on `oven/bun:1.3.14-slim`, so it is not a platform quirk. It is **replaced by the native `Bun.Terminal` API**, which passes the identical test on both platforms — sustained multi-command session, `test -t 0` true inside the child, `stty size` reflecting a mid-session resize. Net effect: the migration removes a native dependency rather than working around it.

**bcrypt hashes are bidirectionally compatible with `Bun.password`.** Existing `$2b$` hashes verify under Bun, and Bun-written hashes verify under npm `bcrypt`. No password migration or forced reset, and the change stays reversible. Bun's default algorithm is argon2id, so `{ algorithm: "bcrypt" }` is mandatory on every hash call — that one is a one-way door.

**`ssh2` and `dockerode` pass fully under Bun.** ssh2 verified against a real sshd container: handshake, exec channel, stdout streaming, interactive shell channel. dockerode verified against the Docker socket: ping, listContainers, log stream, stats.

**`drizzle-orm/bun-sql` already ships in the pinned 0.45.2.** No drizzle upgrade needed to move onto `Bun.sql`.

## Two things the plan deliberately does not do

`Bun.$` does **not** replace `execAsync`. That code runs pre-assembled command strings and also dispatches to ssh2 for remote execution; `Bun.$` escapes interpolations, so feeding it raw strings needs `.raw` or `sh -c`, which reopens the injection surface for no gain. Bun implements `node:child_process` natively anyway.

No repo-wide rename. 590 files mention "dokploy" — renaming them would make every future upstream merge conflict in every touched file, permanently. Identity gets centralised behind constants instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)