### PR TITLE
docs: rewrite README around measured results, record CI benchmarks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,20 @@ Never reintroduce one, and never write a script that mutates its `package.json`
 **`bun build` does not typecheck.** A green build says nothing about types. Run
 `typecheck` separately, always, before claiming a change compiles.
 
+**And a green typecheck says nothing about the build.** `typecheck` resolves through
+tsconfig `paths`; the build does not. Both have to run.
+
+### Before opening a PR
+
+Two failures in this migration reached CI because the local environment was richer than
+a clean checkout. Both are cheap to prevent:
+
+1. **Edited any `package.json`?** Run `bun install` and commit `bun.lock` in the same
+   commit. CI runs `--frozen-lockfile` and a stale lockfile fails it instantly.
+2. **Verify from clean.** `rm -rf node_modules && bun install --frozen-lockfile`, then
+   `bun run --filter '*' typecheck && bun run build`. Passing against a warm
+   `node_modules` proves less than it appears to.
+
 ### Native dependencies
 
 `node-pty`, `ssh2`, `bcrypt`, `better-sqlite3`, `sharp` and friends need postinstall

--- a/README.md
+++ b/README.md
@@ -2,63 +2,217 @@
   <a href="https://dokploy.com">
     <img src=".github/sponsors/logo.png" alt="Dokploy - Open Source Alternative to Vercel, Heroku and Netlify." width="100%"  />
   </a>
-  </br>
-  </br>
-  <p>Join us on Discord for help, feedback, and discussions!</p>
-  <a href="https://discord.gg/2tBnJ3jDJc">
-    <img src="https://discordapp.com/api/guilds/1234073262418563112/widget.png?style=banner2" alt="Discord Shield"/>
-  </a>
 </div>
 <br />
 
+# dokploy-bun
 
-Dokploy is a free, self-hostable Platform as a Service (PaaS) that simplifies the deployment and management of applications and databases.
+A fork of [Dokploy](https://github.com/Dokploy/dokploy) that runs the whole stack on
+[Bun](https://bun.sh) instead of Node.js + pnpm.
 
-## ✨ Features
+Dokploy is excellent software. This fork does not try to change what it does — it changes
+what it runs on, measures the result, and writes down what breaks.
 
-Dokploy includes multiple features to make your life easier.
+---
 
-- **Applications**: Deploy any type of application (Node.js, PHP, Python, Go, Ruby, etc.).
-- **Databases**: Create and manage databases with support for MySQL, PostgreSQL, MongoDB, MariaDB, libsql, and Redis.
-- **Backups**: Automate backups for databases to an external storage destination.
-- **Docker Compose**: Native support for Docker Compose to manage complex applications.
-- **Multi Node**: Scale applications to multiple nodes using Docker Swarm to manage the cluster.
-- **Templates**: Deploy open-source templates (Plausible, Pocketbase, Calcom, etc.) with a single click.
-- **Traefik Integration**: Automatically integrates with Traefik for routing and load balancing.
-- **Real-time Monitoring**: Monitor CPU, memory, storage, and network usage for every resource.
-- **Docker Management**: Easily deploy and manage Docker containers.
-- **CLI/API**: Manage your applications and databases using the command line or through the API.
-- **Notifications**: Get notified when your deployments succeed or fail (via Slack, Discord, Telegram, Email, etc.).
-- **Multi Server**: Deploy and manage your applications remotely to external servers.
-- **Self-Hosted**: Self-host Dokploy on your VPS.
+## Why this exists
 
-## 🚀 Getting Started
+Moving a self-hosted PaaS to a different runtime is a real risk to take on behalf of
+everyone running it in production, and upstream is understandably cautious about it.
+That caution deserves evidence rather than enthusiasm.
 
-To get started, run the following command on a VPS:
+So this fork exists to answer one question honestly: **does Bun actually run this, and
+what does it cost?** Including — especially — the parts where the answer is "no".
 
-Want to skip the installation process? [Try the Dokploy Cloud](https://app.dokploy.com).
+Everything below was measured or reproduced, with Node as a control where a comparison
+was possible. Where something is untested, it says so.
+
+---
+
+## Status
+
+The migration is [planned in nine phases](docs/bun-migration/PLAN.md). **Three are done.**
+
+| Phase | What | Status |
+|---|---|---|
+| 0 | Native module spike (`node-pty`, `ssh2`, `dockerode`) | ✅ done |
+| 1 | Package manager: pnpm → bun | ✅ done |
+| 2 | TypeScript on Bun, no `packages/server` build | ✅ done |
+| 3 | Bundler: esbuild → `bun build` (apps/dokploy) | ⬜ |
+| 4 | **Runtime: Node → Bun** (custom server, 6 WebSocket servers) | ⬜ |
+| 5 | Native APIs (`Bun.Terminal`, `Bun.password`, `Bun.sql`) | ⬜ |
+| 6 | Dependency cleanup | ⬜ |
+| 7 | Docker + CI | ⬜ |
+| 9 | Tests: vitest → `bun test`, gradually | ⬜ |
+
+> **The web app still executes on Node in production.** Phase 4 is where that changes.
+> Nothing here is yet a claim about runtime performance.
+
+---
+
+## What has actually been proven
+
+### Bun runs Dokploy's full test suite
+
+**All 874 tests pass on Bun in CI** — deploys, traefik, SSH, docker, compose, backups,
+permissions. This is the single most useful data point so far, and it is stronger than
+any timing number.
+
+### `next build` works on Bun
+
+Next.js does not officially support Bun as a runtime, so this was the biggest expected
+risk. It builds — 49.7s locally, green in CI.
+
+### bcrypt hashes are compatible in both directions
+
+Tested both ways: existing `$2b$` hashes from the database verify under `Bun.password`,
+**and** Bun-written hashes verify under npm `bcrypt`. So moving to `Bun.password` needs
+**no password migration and no forced reset**, and a rollback to Node does not strand
+anyone.
+
+One trap: Bun's default hash algorithm is argon2id, which npm `bcrypt` cannot read.
+`{ algorithm: "bcrypt" }` is mandatory on every call — that one is a one-way door.
+
+### `ssh2` and `dockerode` work unchanged
+
+`ssh2` verified against a real sshd container — handshake, exec channel, stdout
+streaming, interactive shell. `dockerode` verified against a live Docker socket — ping,
+container listing, log streaming, stats. These carry every remote-server operation
+Dokploy performs, and they needed no changes.
+
+### `node-pty` does **not** work on Bun
+
+The honest one. Under Bun the PTY child exits ~8ms after spawn and `resize()` throws
+`EBADF`. Reproduced identically on macOS arm64 and inside `oven/bun:1.3.14-slim`, with
+Node as a control passing the same test.
+
+It is replaced by Bun's native `Bun.Terminal`, which passes the identical test on both
+platforms — sustained multi-command session, a real tty inside the child, and `stty size`
+correctly reflecting a mid-session resize. **Net effect: one fewer native dependency.**
+
+Details and reproductions: [SPIKE-RESULTS.md](docs/bun-migration/SPIKE-RESULTS.md).
+
+---
+
+## Measurements
+
+### Install and repository weight
+
+| | pnpm | bun |
+|---|---|---|
+| `install --frozen-lockfile`, warm cache | 21.9s | **13.4s** first / **5.5s** after |
+| Lockfile | 656 KB | **485 KB** |
+| `node_modules` | 1.5G | **1.5G — no change** |
+
+`bun install` migrated `pnpm-lock.yaml` to `bun.lock` by itself on first run.
+
+### CI wall-times
+
+Same runner, same code, toolchain swapped.
+
+| Job | pnpm | bun (phase 2) |
+|---|---|---|
+| `build` | 3m51s | **2m39s** |
+| `test` | 4m31s | 3m44s |
+| `typecheck` | 1m25s | 1m6s |
+
+⚠️ **These are single runs on shared CI runners.** Treat anything under ~15s as noise.
+Only `build` moved far enough to be a real signal, and the cause is known rather than
+guessed: phase 2 deleted the `packages/server` build step, so that is work *removed*, not
+work sped up. `test` and `typecheck` improved, but not yet by enough to claim.
+
+### Dependencies and code removed
+
+Removed so far: `tsx` (×4), `rimraf` (×3), `esbuild` + `esbuild-plugin-alias`,
+`tsc-alias`. Seven files and **18,678 lines** deleted, including `pnpm-lock.yaml`,
+`pnpm-workspace.yaml`, and two scripts described below.
+
+More removals are queued for phase 6 — `dotenv`, `@hono/node-server`, `bcrypt`,
+`postgres`, `undici`, and `node-pty`.
+
+### The change that is not a number
+
+`packages/server` shipped two scripts, `switchToSrc.js` and `switchToDist.js`, that
+**rewrote the package's own `exports` field in place** — pointing at `src/*.ts` during
+development and `dist/*.cjs.js` in production. They existed only because Node cannot
+import TypeScript across a workspace boundary.
+
+Bun resolves the source directly, so both scripts, the build step they served, and the
+entire "works in dev, breaks in prod" failure mode are gone. That is worth more than the
+seconds saved.
+
+---
+
+## What is not proven yet
+
+Stated plainly, because a benchmark table that omits its gaps is not worth reading:
+
+- **No runtime performance data.** The server still runs on Node until phase 4. Nothing
+  here says anything about request latency, throughput, or memory.
+- **No production evidence.** No instance has run under sustained real load.
+- **No Docker image comparison.** Image size and cold-boot time come with phase 7.
+- **`node_modules` did not shrink.** 1.5G before, 1.5G after.
+
+## Known broken
+
+- **Docker builds fail** on this branch. Phase 1 deleted `pnpm-lock.yaml` while the
+  Dockerfiles still run `pnpm install --frozen-lockfile`. Fixed in phase 7. **No release
+  can be cut from this line until then.**
+
+---
+
+## Trying it
+
+Not yet packaged for installation. Until phase 7 lands, install upstream Dokploy
+normally:
 
 ```bash
 curl -sSL https://dokploy.com/install.sh | bash
 ```
 
-For detailed documentation, visit [docs.dokploy.com](https://docs.dokploy.com).
+To work on this fork:
 
+```bash
+git clone https://github.com/SashaGoncharov19/dokploy-bun.git
+cd dokploy-bun
+bun install
+bun run --filter '*' typecheck
+bun run test
+```
 
-[Github Sponsors](https://github.com/sponsors/Siumauricio)
+Requires [Bun](https://bun.sh) 1.3.14+. Node.js and pnpm are no longer needed.
 
-### Contributors 🤝
+---
 
-<a href="https://github.com/dokploy/dokploy/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=dokploy/dokploy" alt="Contributors" />
-</a>
+## Relationship to upstream
 
-## 📺 Video Tutorial
+This fork tracks [Dokploy/dokploy](https://github.com/Dokploy/dokploy) and pulls its
+updates in deliberately — see [FORK-STRATEGY.md](docs/FORK-STRATEGY.md).
 
-<a href="https://youtu.be/mznYKPvhcfw">
-  <img src="https://dokploy.com/banner.png" alt="Watch the video" width="400"/>
-</a>
+It stays **structurally identical** to upstream on purpose. No repo-wide rename, no
+reformatting, no restructuring: 590 files mention "dokploy", and renaming them would make
+every future upstream merge conflict in every touched file, permanently. The migration is
+built as small independent phases against upstream's own layout, so any of it can be
+offered back.
 
-## 🤝 Contributing
+Credit for Dokploy itself belongs to [its authors and
+contributors](https://github.com/dokploy/dokploy/graphs/contributors). Licensing follows
+upstream: [Apache-2.0](LICENSE.MD), except `/proprietary` directories under
+[DSAL](LICENSE_PROPRIETARY.md).
 
-Check out the [Contributing Guide](CONTRIBUTING.md) for more information.
+---
+
+## What Dokploy does
+
+Unchanged by this fork — see [docs.dokploy.com](https://docs.dokploy.com).
+
+Applications in any language · MySQL, PostgreSQL, MongoDB, MariaDB, libsql and Redis ·
+automated backups · Docker Compose · multi-node Docker Swarm · one-click open-source
+templates · Traefik routing · real-time CPU/memory/storage/network monitoring · CLI and
+API · deployment notifications via Slack, Discord, Telegram and email · remote multi-server
+deployment · fully self-hosted.
+
+## Contributing
+
+See the [Contributing Guide](CONTRIBUTING.md). Branch names follow
+[docs/BRANCHING.md](docs/BRANCHING.md); working conventions are in [CLAUDE.md](CLAUDE.md).

--- a/docs/bun-migration/SPIKE-RESULTS.md
+++ b/docs/bun-migration/SPIKE-RESULTS.md
@@ -146,9 +146,53 @@ Captured on this machine (macOS arm64), pnpm 10.22.0 provisioned via corepack.
 
 `bun install` migrated `pnpm-lock.yaml` to `bun.lock` automatically on first run.
 
-**Not yet measured:** build wall-times, Docker image sizes, server cold-boot time and
-RSS. Those become meaningful after Phases 3–4 and 7, when the build and runtime actually
-change; measuring them now would only re-measure the Node toolchain.
+**Not yet measured:** Docker image sizes, server cold-boot time and RSS. Those become
+meaningful after Phases 4 and 7, when the runtime actually changes; measuring them now
+would only re-measure Node.
+
+### CI wall-times — same runner, same code, toolchain swapped
+
+GitHub-hosted `ubuntu-latest`, one run per configuration.
+
+| Job | pnpm (baseline) | Phase 1 — bun | Phase 2 — bun, no server build |
+|---|---|---|---|
+| `build` | 3m51s | 3m41s | **2m39s** |
+| `test` | 4m31s | 3m29s | 3m44s |
+| `typecheck` | 1m25s | 56s | 1m6s |
+| `format` | 10s | 12s | 8s |
+
+⚠️ **n=1 per configuration.** These are single runs on shared runners, so treat
+differences under roughly 15s as noise — `format`, and the `test`/`typecheck` movement
+between Phase 1 and Phase 2, are all inside that band. Only `build` moved far enough to
+be a real signal, and its cause is known rather than inferred: Phase 2 deleted the
+`server:build` step entirely, so the drop is work removed, not work sped up.
+
+The honest summary is **"build got meaningfully shorter, the rest is not yet
+distinguishable from noise."** Repeated runs would be needed to claim more.
+
+### The result that actually matters
+
+**All 874 tests pass on Bun in CI**, including the 4 that fail locally for want of
+`docker swarm init`. The full Dokploy test suite — deploys, traefik, SSH, docker,
+compose, backups, permissions — runs green on Bun.
+
+That is a stronger statement than any timing number, and it is the one to lead with.
+
+### Two failures CI caught that local runs did not
+
+Both had the same root cause: **the local environment was richer than a clean checkout.**
+
+1. **`apps/api` / `apps/schedules` builds.** Removing the `packages/server` build broke
+   their `tsc` builds, because both compiled against the generated `dist` declarations.
+   Typecheck stayed green — it resolves via tsconfig `paths` — so only running the real
+   build surfaced it.
+2. **Lockfile drift.** Dependencies were removed from manifests without re-running
+   `bun install`, so `bun.lock` went stale and `--frozen-lockfile` failed in CI. Local
+   builds passed because `node_modules` already had everything.
+
+**Process rule taken from this:** after any `package.json` edit, run `bun install` and
+commit the lockfile, and do the final pre-PR verification from `rm -rf node_modules`.
+A green typecheck is not evidence that the build works.
 
 ### Test failures are environmental, not migration-caused
 


### PR DESCRIPTION
The README described the upstream product. It now describes **this fork** — what it is, what has been proven, and what has not.

## Framing

Deliberately conservative, because an overstated benchmark is worse than none. The migration is 3 of 9 phases in and **the web app still runs on Node**, so the README makes **no runtime performance claims at all**.

It states plainly what is *not* proven:
- No runtime performance data — the server moves to Bun in phase 4
- No production evidence under real load
- No Docker image comparison
- `node_modules` did not shrink: 1.5G before, 1.5G after

And puts the broken Docker builds under a **Known broken** heading rather than leaving them to be discovered.

## What the README leads with

Not a timing number — **all 874 tests pass on Bun in CI**. Deploys, traefik, SSH, docker, compose, backups, permissions. That is a much stronger statement than any wall-time delta.

Then, in order: `next build` works on Bun; bcrypt hashes are bidirectionally compatible with `Bun.password` so no password migration is needed; `ssh2` and `dockerode` work unchanged; and **`node-pty` does not work on Bun** — replaced by native `Bun.Terminal`, which nets out to one fewer native dependency.

The failure is included on purpose. A migration report with no failures in it does not read as one where anyone looked.

## Benchmarks, with their caveats

| Job | pnpm | bun (phase 2) |
|---|---|---|
| `build` | 3m51s | **2m39s** |
| `test` | 4m31s | 3m44s |
| `typecheck` | 1m25s | 1m6s |

Marked clearly as **n=1 on shared runners**. Only `build` moved beyond noise, and its cause is known rather than inferred — phase 2 deleted the `server:build` step, so that is work *removed*, not work sped up. Claiming the `test` and `typecheck` deltas would need repeated runs, so the README does not claim them.

## Process rule

Records the two failures CI caught that local runs did not — `tsc` compiling against generated declarations, and a stale lockfile — both with the same root cause: **the local environment was richer than a clean checkout.**

Turned into a pre-PR rule in `CLAUDE.md`: run `bun install` after any manifest edit and commit the lockfile, and do the final verification from `rm -rf node_modules`. A green typecheck is not evidence the build works, and vice versa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)