### PR TITLE
feat: add an install script and publish images to this fork's GHCR

### DIFF
--- a/.github/workflows/dokploy.yml
+++ b/.github/workflows/dokploy.yml
@@ -1,8 +1,13 @@
 name: Dokploy Docker Build
 
+# Upstream's release pipeline: pushes to Docker Hub under dokploy/*, and syncs
+# versions into dokploy/{mcp,cli,sdk}. Neither is ours to do, and the required
+# secrets do not exist on this fork - so it only runs in the upstream repository.
+# This fork publishes via publish-images.yml instead.
+
 on:
   push:
-    branches: [main, canary, "fix/re-apply-database-migration-fix"]
+    branches: [main, canary]
   workflow_dispatch:
 
 env:
@@ -10,6 +15,7 @@ env:
 
 jobs:
   docker-amd:
+    if: github.repository == 'Dokploy/dokploy'
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -50,6 +56,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
   docker-arm:
+    if: github.repository == 'Dokploy/dokploy'
     runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,0 +1,72 @@
+name: Publish images
+
+# Builds and publishes this fork's images to its own GitHub Container Registry.
+# Upstream's dokploy.yml pushes to Docker Hub under dokploy/* with secrets this
+# fork does not have, so it is disabled here (see the guard in that file).
+#
+# GHCR authenticates with the built-in GITHUB_TOKEN - no secrets to configure.
+
+on:
+  push:
+    branches: [main, canary]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - dockerfile: Dockerfile
+            suffix: ""
+          - dockerfile: Dockerfile.server
+            suffix: "-api"
+          - dockerfile: Dockerfile.schedule
+            suffix: "-schedules"
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve tag
+        id: meta
+        run: |
+          # GHCR requires a lowercase image path
+          image="$(echo "${REGISTRY}/${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')${{ matrix.suffix }}"
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            tag="latest"
+          else
+            tag="canary"
+          fi
+          echo "tags=${image}:${tag},${image}:${{ github.sha }}" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare env file
+        run: |
+          cp apps/dokploy/.env.production.example .env.production
+          cp apps/dokploy/.env.production.example apps/dokploy/.env.production
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -129,6 +129,25 @@ Only `build` moved far enough to be a real signal, and the cause is known rather
 guessed: phase 2 deleted the `packages/server` build step, so that is work *removed*, not
 work sped up. `test` and `typecheck` improved, but not yet by enough to claim.
 
+### Docker images
+
+Built from the same commit range, on the same machine.
+
+| Image | Node + pnpm | Bun | |
+|---|---|---|---|
+| api | 1.25GB | **234MB** | **5.3× smaller** |
+| schedules | — | **232MB** | — |
+| main (web app) | 3.25GB | 3.22GB | unchanged |
+
+The api image drops from **1.25GB to 234MB** because it ships **no `node_modules` at
+all** — `bun build` produces a self-contained bundle and extracts the native addons
+beside it, so `dist/` is the whole application.
+
+**The main image is the same size, and that is the honest result.** Its bulk is the
+docker CLI, nixpacks, railpack, buildpacks and rclone — none of which a runtime swap
+touches. Next.js still needs `node_modules` at runtime, so the same trick does not
+apply there.
+
 ### Dependencies and code removed
 
 Removed: `tsx` (×4), `rimraf` (×3), `esbuild` + `esbuild-plugin-alias`, `tsc-alias`,
@@ -172,16 +191,31 @@ Stated plainly, because a benchmark table that omits its gaps is not worth readi
 
 ---
 
-## Trying it
+## Installing
 
-Not yet packaged for installation. Until phase 7 lands, install upstream Dokploy
-normally:
+On a fresh VPS, as root:
 
 ```bash
-curl -sSL https://dokploy.com/install.sh | bash
+curl -sSL https://raw.githubusercontent.com/SashaGoncharov19/dokploy-bun/canary/install.sh | sh
 ```
 
-To work on this fork:
+The script is upstream's, changed in exactly two ways: images come from this
+repository's GitHub Container Registry (`ghcr.io/sashagoncharov19/dokploy-bun`)
+rather than Docker Hub, and version detection follows **this** repository's
+releases. Both are overridable — `DOKPLOY_IMAGE` and `DOKPLOY_REPO` — if you build
+your own.
+
+To update an existing install:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/SashaGoncharov19/dokploy-bun/canary/install.sh | sh -s update
+```
+
+⚠️ **This installs a PaaS that manages Docker on the host.** It initialises Docker
+Swarm, creates an overlay network and writes to `/etc/dokploy`. Run it on a machine
+you intend to dedicate to it, not your laptop.
+
+## Working on it
 
 ```bash
 git clone https://github.com/SashaGoncharov19/dokploy-bun.git

--- a/docs/bun-migration/SPIKE-RESULTS.md
+++ b/docs/bun-migration/SPIKE-RESULTS.md
@@ -233,6 +233,26 @@ runner while Next itself executes on Node (`bun --bun` forces otherwise). A cust
 that imports `next()` in-process, as Dokploy does, genuinely runs Next inside Bun — which
 is why this hit us and does not hit those templates.
 
+### Docker image sizes
+
+Same machine, pre-migration commit vs now.
+
+| Image | Node + pnpm | Bun | |
+|---|---|---|---|
+| api | 1.25GB | **234MB** | 5.3× smaller |
+| schedules | — | **232MB** | — |
+| main (web app) | 3.25GB | 3.22GB | **unchanged** |
+
+The service images collapse because `bun build` emits a self-contained bundle and
+extracts the native addons next to it, so the runtime image ships `dist/` and nothing
+else — no `node_modules`.
+
+The main image does **not** shrink, and that is worth stating rather than omitting: its
+bulk is the docker CLI, nixpacks, railpack, buildpacks, rclone and git-lfs. A runtime
+swap cannot touch any of that, and Next.js still needs `node_modules` at runtime, so the
+self-contained trick does not apply. Anyone expecting "Bun makes images smaller" as a
+general claim should look at these two rows and take the specific one.
+
 ### `apps/schedules` had been broken since phase 2, and nothing caught it
 
 `bun build --packages=external` leaves every `node_modules` import external. For these

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,416 @@
+#!/bin/bash
+
+# Docker version to install and maintain
+DOCKER_VERSION="28.5.0"
+
+# This is the Bun fork of Dokploy: https://github.com/SashaGoncharov19/dokploy-bun
+# Images are published to this repository's GitHub Container Registry, and version
+# detection follows this repository's releases - not upstream's. Override either
+# with DOKPLOY_IMAGE / DOKPLOY_REPO if you host your own build.
+DOKPLOY_REPO="${DOKPLOY_REPO:-SashaGoncharov19/dokploy-bun}"
+DOKPLOY_IMAGE="${DOKPLOY_IMAGE:-ghcr.io/sashagoncharov19/dokploy-bun}"
+
+# Detect version from environment variable or default to latest
+# Usage with curl (export first): export DOKPLOY_VERSION=canary && curl -sSL https://raw.githubusercontent.com/SashaGoncharov19/dokploy-bun/canary/install.sh | sh
+# Usage with curl (export first): export DOKPLOY_VERSION=latest && curl -sSL https://raw.githubusercontent.com/SashaGoncharov19/dokploy-bun/canary/install.sh | sh
+# Usage with curl (bash -s): DOKPLOY_VERSION=canary bash -s < <(curl -sSL https://raw.githubusercontent.com/SashaGoncharov19/dokploy-bun/canary/install.sh)
+# Usage with curl (default): curl -sSL https://raw.githubusercontent.com/SashaGoncharov19/dokploy-bun/canary/install.sh | sh (detects latest stable version)
+# Usage with bash: DOKPLOY_VERSION=canary bash install.sh
+# Usage with bash: DOKPLOY_VERSION=latest bash install.sh
+# Usage with bash: bash install.sh (detects latest stable version)
+detect_version() {
+    local version="${DOKPLOY_VERSION}"
+    
+    # If no version specified, get latest stable version from GitHub releases
+    if [ -z "$version" ]; then
+        echo "Detecting latest stable version from GitHub..." >&2
+        
+        # Try to get latest release from GitHub by following redirects
+        version=$(curl -fsSL --connect-timeout 10 -o /dev/null -w '%{url_effective}\n' \
+            https://github.com/${DOKPLOY_REPO}/releases/latest 2>/dev/null | \
+            sed 's#.*/tag/##')
+
+        # When the request fails (unreachable network, rate limit), curl still
+        # prints the attempted URL, which would produce an invalid image tag
+        # like <image>:https://... Accept only values that look like a
+        # release tag (e.g. v0.29.10).
+        case "$version" in
+            v[0-9]*) ;;
+            *) version="" ;;
+        esac
+
+        # Fallback to latest tag if detection fails
+        if [ -z "$version" ]; then
+            echo "Warning: Could not detect latest version from GitHub, using fallback version latest" >&2
+            version="latest"
+        else
+            echo "Latest stable version detected: $version" >&2
+        fi
+    fi
+    
+    echo "$version"
+}
+
+# Function to detect if running in Proxmox LXC container
+is_proxmox_lxc() {
+    # Check for LXC in environment
+    if [ -n "$container" ] && [ "$container" = "lxc" ]; then
+        return 0  # LXC container
+    fi
+    
+    # Check for LXC in /proc/1/environ
+    if grep -q "container=lxc" /proc/1/environ 2>/dev/null; then
+        return 0  # LXC container
+    fi
+    
+    return 1  # Not LXC
+}
+
+generate_random_password() {
+    # Generate a secure random password using multiple methods with fallbacks
+    local password=""
+    
+    # Try using openssl (most reliable, available on most systems)
+    if command -v openssl >/dev/null 2>&1; then
+        password=$(openssl rand -base64 32 | tr -d "=+/" | cut -c1-32)
+    # Fallback to /dev/urandom with tr (most Linux systems)
+    elif [ -r /dev/urandom ]; then
+        password=$(tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 32)
+    # Last resort fallback using date and simple hashing
+    else
+        if command -v sha256sum >/dev/null 2>&1; then
+            password=$(date +%s%N | sha256sum | base64 | head -c 32)
+        elif command -v shasum >/dev/null 2>&1; then
+            password=$(date +%s%N | shasum -a 256 | base64 | head -c 32)
+        else
+            # Very basic fallback - combines multiple sources of entropy
+            password=$(echo "$(date +%s%N)-$(hostname)-$$-$RANDOM" | base64 | tr -d "=+/" | head -c 32)
+        fi
+    fi
+    
+    # Ensure we got a password of correct length
+    if [ -z "$password" ] || [ ${#password} -lt 20 ]; then
+        echo "Error: Failed to generate random password" >&2
+        exit 1
+    fi
+    
+    echo "$password"
+}
+
+install_dokploy() {
+    # Detect version tag
+    VERSION_TAG=$(detect_version)
+    DOCKER_IMAGE="${DOKPLOY_IMAGE}:${VERSION_TAG}"
+    
+    echo "Installing Dokploy version: ${VERSION_TAG}"
+    if [ "$(id -u)" != "0" ]; then
+        echo "This script must be run as root" >&2
+        exit 1
+    fi
+
+    # check if is Mac OS
+    if [ "$(uname)" = "Darwin" ]; then
+        echo "This script must be run on Linux" >&2
+        exit 1
+    fi
+
+    # check if is running inside a container
+    if [ -f /.dockerenv ]; then
+        echo "This script must be run on Linux" >&2
+        exit 1
+    fi
+
+    # check if something is running on port 80
+    if ss -tulnp | grep ':80 ' >/dev/null; then
+        echo "Error: something is already running on port 80" >&2
+        exit 1
+    fi
+
+    # check if something is running on port 443
+    if ss -tulnp | grep ':443 ' >/dev/null; then
+        echo "Error: something is already running on port 443" >&2
+        exit 1
+    fi
+
+    # check if something is running on port 3000
+    if ss -tulnp | grep ':3000 ' >/dev/null; then
+        echo "Error: something is already running on port 3000" >&2
+        echo "Dokploy requires port 3000 to be available. Please stop any service using this port." >&2
+        exit 1
+    fi
+
+    command_exists() {
+      command -v "$@" > /dev/null 2>&1
+    }
+
+    if command_exists docker; then
+      echo "Docker already installed"
+    else
+      curl -sSL https://get.docker.com | sh -s -- --version $DOCKER_VERSION
+      # Hold docker packages to prevent unintended upgrades (apt-based distros only)
+      if command_exists apt-mark; then
+        apt-mark hold docker-ce docker-ce-cli docker-ce-rootless-extras
+      fi
+    fi
+
+    # Check if running in Proxmox LXC container and set endpoint mode
+    endpoint_mode=""
+    if [ "$ENDPOINT_MODE" = "dnsrr" ]; then
+        echo "ENDPOINT_MODE=dnsrr set — adding --endpoint-mode dnsrr to Docker services."
+        echo "Use this on kernels without IPVS support (e.g. ZimaOS / Buildroot-based images)."
+        echo ""
+        endpoint_mode="--endpoint-mode dnsrr"
+    elif is_proxmox_lxc; then
+        echo "⚠️ WARNING: Detected Proxmox LXC container environment!"
+        echo "Adding --endpoint-mode dnsrr to Docker services for LXC compatibility."
+        echo "This may affect service discovery but is required for LXC containers."
+        echo ""
+        endpoint_mode="--endpoint-mode dnsrr"
+        echo "Waiting for 5 seconds before continuing..."
+        sleep 5
+    fi
+
+
+    docker swarm leave --force 2>/dev/null
+
+    get_ip() {
+        local ip=""
+        
+        # Try IPv4 first
+        # First attempt: ifconfig.io
+        ip=$(curl -4s --connect-timeout 5 https://ifconfig.io 2>/dev/null)
+        
+        # Second attempt: icanhazip.com
+        if [ -z "$ip" ]; then
+            ip=$(curl -4s --connect-timeout 5 https://icanhazip.com 2>/dev/null)
+        fi
+        
+        # Third attempt: ipecho.net
+        if [ -z "$ip" ]; then
+            ip=$(curl -4s --connect-timeout 5 https://ipecho.net/plain 2>/dev/null)
+        fi
+
+        # If no IPv4, try IPv6
+        if [ -z "$ip" ]; then
+            # Try IPv6 with ifconfig.io
+            ip=$(curl -6s --connect-timeout 5 https://ifconfig.io 2>/dev/null)
+            
+            # Try IPv6 with icanhazip.com
+            if [ -z "$ip" ]; then
+                ip=$(curl -6s --connect-timeout 5 https://icanhazip.com 2>/dev/null)
+            fi
+            
+            # Try IPv6 with ipecho.net
+            if [ -z "$ip" ]; then
+                ip=$(curl -6s --connect-timeout 5 https://ipecho.net/plain 2>/dev/null)
+            fi
+        fi
+
+        if [ -z "$ip" ]; then
+            echo "Error: Could not determine server IP address automatically (neither IPv4 nor IPv6)." >&2
+            echo "Please set the ADVERTISE_ADDR environment variable manually." >&2
+            echo "Example: export ADVERTISE_ADDR=<your-server-ip>" >&2
+            exit 1
+        fi
+
+        echo "$ip"
+    }
+
+    get_private_ip() {
+        # Pick the first private (RFC1918) IP from a real interface. Docker-created
+        # interfaces (docker0, br-*, veth*) are excluded: their IPs (e.g. 172.17.0.1)
+        # are host-local and never reachable from other swarm nodes.
+        ip -o -4 addr show scope global \
+            | awk '$2 !~ /^(docker|br-|veth)/ {print $4}' \
+            | cut -d/ -f1 \
+            | grep -E "^(192\.168\.|10\.|172\.(1[6-9]|2[0-9]|3[01])\.)" \
+            | head -n1
+    }
+
+    advertise_addr="${ADVERTISE_ADDR:-$(get_private_ip)}"
+
+    # Servers with only a public IP have no private interface: fall back to the public IP
+    if [ -z "$advertise_addr" ]; then
+        advertise_addr=$(get_ip)
+    fi
+
+    if [ -z "$advertise_addr" ]; then
+        echo "ERROR: We couldn't detect your server IP address."
+        echo "Please set the ADVERTISE_ADDR environment variable manually."
+        echo "Example: curl -sSL https://raw.githubusercontent.com/SashaGoncharov19/dokploy-bun/canary/install.sh | sudo ADVERTISE_ADDR=192.168.1.100 sh"
+        exit 1
+    fi
+    echo "Using advertise address: $advertise_addr"
+
+    # Allow custom Docker Swarm init arguments via DOCKER_SWARM_INIT_ARGS environment variable
+    # Example: export DOCKER_SWARM_INIT_ARGS="--default-addr-pool 172.20.0.0/16 --default-addr-pool-mask-length 24"
+    # This is useful to avoid CIDR overlapping with cloud provider VPCs (e.g., AWS)
+    swarm_init_args="${DOCKER_SWARM_INIT_ARGS:-}"
+    
+    if [ -n "$swarm_init_args" ]; then
+        echo "Using custom swarm init arguments: $swarm_init_args"
+        docker swarm init --advertise-addr $advertise_addr $swarm_init_args
+    else
+        docker swarm init --advertise-addr $advertise_addr
+    fi
+    
+     if [ $? -ne 0 ]; then
+        echo "Error: Failed to initialize Docker Swarm" >&2
+        exit 1
+    fi
+
+    echo "Swarm initialized"
+
+    docker network rm -f dokploy-network 2>/dev/null
+    docker network create --driver overlay --attachable dokploy-network
+
+    echo "Network created"
+
+    mkdir -p /etc/dokploy
+
+    chmod 777 /etc/dokploy
+
+    # Generate secure random password for Postgres
+    POSTGRES_PASSWORD=$(generate_random_password)
+
+    # Store password as Docker Secret (encrypted and secure)
+    echo "$POSTGRES_PASSWORD" | docker secret create dokploy_postgres_password - 2>/dev/null || true
+
+    # Generate secure auth secret for Better Auth
+    AUTH_SECRET=$(openssl rand -hex 32)
+
+    # Store auth secret as Docker Secret (encrypted and secure)
+    echo "$AUTH_SECRET" | docker secret create dokploy_auth_secret - 2>/dev/null || true
+
+    echo "Generated secure database credentials and auth secret (stored in Docker Secrets)"
+
+    docker service create \
+    --name dokploy-postgres \
+    --constraint 'node.role==manager' \
+    --network dokploy-network \
+    --env POSTGRES_USER=dokploy \
+    --env POSTGRES_DB=dokploy \
+    --secret source=dokploy_postgres_password,target=/run/secrets/postgres_password \
+    --env POSTGRES_PASSWORD_FILE=/run/secrets/postgres_password \
+    --mount type=volume,source=dokploy-postgres,target=/var/lib/postgresql/data \
+    $endpoint_mode \
+    postgres:16
+
+    # Installation
+    # Set RELEASE_TAG environment variable for canary/feature versions
+    # POSIX-compatible (no [[ ]]): the script is documented as `curl ... | sh`,
+    # and on Debian/Ubuntu sh is dash, which has no [[ or =~ (issue #157)
+    release_tag_env=""
+    case "$VERSION_TAG" in
+        v[0-9]*.[0-9]*.[0-9]*)
+            # Specific version (v0.26.6, v0.26.7, etc.) → latest
+            release_tag_env="-e RELEASE_TAG=latest"
+            ;;
+        latest)
+            ;;
+        *)
+            # canary, feature/*, etc. → use the tag as-is
+            release_tag_env="-e RELEASE_TAG=$VERSION_TAG"
+            ;;
+    esac
+    
+    docker service create \
+      --name dokploy \
+      --replicas 1 \
+      --network dokploy-network \
+      --mount type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock \
+      --mount type=bind,source=/etc/dokploy,target=/etc/dokploy \
+      --mount type=volume,source=dokploy,target=/root/.docker \
+      --secret source=dokploy_postgres_password,target=/run/secrets/postgres_password \
+      --secret source=dokploy_auth_secret,target=/run/secrets/dokploy_auth_secret \
+      --publish published=3000,target=3000,mode=host \
+      --update-parallelism 1 \
+      --update-order stop-first \
+      --constraint 'node.role == manager' \
+      $endpoint_mode \
+      $release_tag_env \
+      -e POSTGRES_PASSWORD_FILE=/run/secrets/postgres_password \
+      -e BETTER_AUTH_SECRET_FILE=/run/secrets/dokploy_auth_secret \
+      $DOCKER_IMAGE
+
+    sleep 4
+
+    docker run -d \
+        --name dokploy-traefik \
+        --restart always \
+        --network dokploy-network \
+        -v /etc/dokploy/traefik/traefik.yml:/etc/traefik/traefik.yml \
+        -v /etc/dokploy/traefik/dynamic:/etc/dokploy/traefik/dynamic \
+        -v /var/run/docker.sock:/var/run/docker.sock:ro \
+        -p 80:80/tcp \
+        -p 443:443/tcp \
+        -p 443:443/udp \
+        traefik:v3.6.7
+
+
+    # Optional: Use docker service create instead of docker run
+    #   docker service create \
+    #     --name dokploy-traefik \
+    #     --constraint 'node.role==manager' \
+    #     --network dokploy-network \
+    #     --mount type=bind,source=/etc/dokploy/traefik/traefik.yml,target=/etc/traefik/traefik.yml \
+    #     --mount type=bind,source=/etc/dokploy/traefik/dynamic,target=/etc/dokploy/traefik/dynamic \
+    #     --mount type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock \
+    #     --publish mode=host,published=443,target=443 \
+    #     --publish mode=host,published=80,target=80 \
+    #     --publish mode=host,published=443,target=443,protocol=udp \
+    #     traefik:v3.6.7
+
+    GREEN="\033[0;32m"
+    YELLOW="\033[1;33m"
+    BLUE="\033[0;34m"
+    NC="\033[0m" # No Color
+
+    format_ip_for_url() {
+        local ip="$1"
+        if echo "$ip" | grep -q ':'; then
+            # IPv6
+            echo "[${ip}]"
+        else
+            # IPv4
+            echo "${ip}"
+        fi
+    }
+
+    public_ip="${ADVERTISE_ADDR:-$(get_ip)}"
+    private_ip=$(get_private_ip)
+    formatted_addr=$(format_ip_for_url "$public_ip")
+    echo ""
+    printf "${GREEN}Congratulations, Dokploy is installed!${NC}\n"
+    printf "${BLUE}Wait 15 seconds for the server to start${NC}\n"
+    printf "${YELLOW}Please go to http://${formatted_addr}:3000${NC}\n"
+    # Home servers and local VMs are often not reachable on their public IP
+    # (no port forwarding), so also print the private IP when there is one.
+    if [ -n "$private_ip" ] && [ "$private_ip" != "$public_ip" ]; then
+        printf "${YELLOW}If you are on the same local network, use http://${private_ip}:3000${NC}\n"
+    fi
+    printf "\n"
+}
+
+update_dokploy() {
+    # Detect version tag
+    VERSION_TAG=$(detect_version)
+    DOCKER_IMAGE="${DOKPLOY_IMAGE}:${VERSION_TAG}"
+
+    echo "Updating Dokploy to version: ${VERSION_TAG}"
+
+    # Pull the image
+    docker pull $DOCKER_IMAGE
+
+    # Update the service
+    docker service update --image $DOCKER_IMAGE dokploy
+
+    echo "Dokploy has been updated to version: ${VERSION_TAG}"
+}
+
+# Main script execution
+if [ "$1" = "update" ]; then
+    update_dokploy
+else
+    install_dokploy
+fi


### PR DESCRIPTION
An install script needs somewhere to pull from, and this fork had nowhere: upstream's `dokploy.yml` pushes to Docker Hub under `dokploy/*` with secrets this fork does not have, and its `sync-version` job writes into `dokploy/{mcp,cli,sdk}` — repositories that are not ours to touch.

## Publishing

`publish-images.yml` builds all three Dockerfiles and pushes them to this repository's **GitHub Container Registry**. GHCR authenticates with the built-in `GITHUB_TOKEN`, so **there is nothing to configure** — no secrets to add. Tags are `canary`/`latest` by branch, plus the commit SHA.

`dokploy.yml` stays in place but is gated on `github.repository == 'Dokploy/dokploy'`. The guard goes on the two leaf jobs; everything downstream is chained through `needs` and skips with them. Guarding rather than deleting keeps the file mergeable with upstream.

## Installing

```bash
curl -sSL https://raw.githubusercontent.com/SashaGoncharov19/dokploy-bun/canary/install.sh | sh
```

Update an existing install:

```bash
curl -sSL https://raw.githubusercontent.com/SashaGoncharov19/dokploy-bun/canary/install.sh | sh -s update
```

`install.sh` is **upstream's script with two changes**, both overridable:

| | |
|---|---|
| `DOKPLOY_IMAGE` | `ghcr.io/sashagoncharov19/dokploy-bun` instead of Docker Hub |
| `DOKPLOY_REPO` | version detection follows **this** repository's releases |

Everything else is untouched — Docker install, swarm setup, Proxmox LXC handling, secret generation, the update path. It passes both `sh -n` and `bash -n`. Keeping the diff to two variables was deliberate: this script sets up Docker Swarm and writes to `/etc/dokploy` on a real server, and it is not the place to be clever.

## Image sizes, measured

Built the pre-migration commit on the same machine for a fair comparison:

| Image | Node + pnpm | Bun | |
|---|---|---|---|
| api | 1.25GB | **234MB** | **5.3× smaller** |
| schedules | — | **232MB** | — |
| main (web app) | 3.25GB | 3.22GB | **unchanged** |

The service images collapse because they ship **no `node_modules` at all** — `bun build` emits a self-contained bundle and extracts the native addons beside it.

**The main image does not shrink, and the README says so plainly.** Its bulk is the docker CLI, nixpacks, railpack, buildpacks and rclone — none of which a runtime swap touches — and Next.js still needs `node_modules` at runtime, so the self-contained trick does not apply. Anyone reading "Bun makes images smaller" as a general claim should look at both rows.

## Note

The first push to `canary` after this merges will populate GHCR. Until then the install script has no images to pull.

🤖 Generated with [Claude Code](https://claude.com/claude-code)