### PR TITLE
test: port the mock-free test directories to bun test

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ Never reintroduce one, and never write a script that mutates its `package.json`
 | bundle | `bun build` — never esbuild |
 | typecheck | `bun run --filter '*' typecheck` (`tsc --noEmit`) |
 | format / lint | `bun run format-and-lint` (biome) |
-| tests | `bun run test` (vitest) — see Tests below |
+| tests | `bun run test` — runs `bun test` **and** vitest, see Tests below |
 
 **`bun build` does not typecheck.** A green build says nothing about types. Run
 `typecheck` separately, always, before claiming a change compiles.
@@ -78,10 +78,18 @@ a clean checkout. Both are cheap to prevent:
 
 ### Native dependencies
 
-`node-pty`, `ssh2`, `bcrypt`, `better-sqlite3`, `sharp` and friends need postinstall
-scripts. Bun only runs those for packages listed in root `package.json`
-**`trustedDependencies`**. Adding a native dep without adding it there produces a
-package that installs fine and fails at runtime. Add it in the same commit.
+`ssh2`, `better-sqlite3`, `sharp` and friends need postinstall scripts. Bun only runs
+those for packages listed in root `package.json` **`trustedDependencies`**. Adding a
+native dep without adding it there produces a package that installs fine and fails at
+runtime. Add it in the same commit.
+
+Two things this list will not tell you:
+
+- **Bun aborts the whole install when any trusted package's script fails**, where pnpm
+  tolerates it. `tree-sitter` is not in the list because it cannot compile against Node
+  24's V8 headers at all — it was never building, pnpm just hid that.
+- **node-gyp needs Node**, which the `oven/bun` image does not ship. The Dockerfiles
+  install Node in the build stage for this reason alone; it never reaches runtime.
 
 ---
 
@@ -96,7 +104,15 @@ Prefer native Bun over the library it replaces:
   `Terminal` as their first argument: `data(terminal, chunk)`, not `data(chunk)`.
 - `Bun.file(p).text()` / `Bun.write()` — over `fs.readFile` / `writeFile` on hot paths
 - Bun auto-loads `.env`. Never `import "dotenv/config"`, never `-r dotenv/config`.
-- `fetch` is native. No `undici`.
+  `dotenv` itself stays a dependency — `utils/docker/utils.ts` uses its `parse()` for
+  user-supplied env files, which is a different job and has no Bun equivalent.
+- `fetch` is native. `undici` stays only for the `FileList` polyfill in
+  `utils/schema.ts`: Bun has `File`, not `FileList`.
+- **`pino` transports do not survive bundling.** `transport: { target: "pino-pretty" }`
+  spawns a worker thread loading `thread-stream/lib/worker.js` by absolute path, which
+  is not in the runtime image. Pass `pino-pretty` as a stream instead.
+- **`bun run x` does not put everything `x` spawns on Bun.** `next build` collects page
+  data in Node child processes, so `build-next` needs `bun --bun`.
 
 ### Two hard rules
 
@@ -124,11 +140,21 @@ implements `node:child_process` natively. Leave it alone.
 
 ## Tests
 
-Vitest today, migrating to `bun test` **gradually**, directory by directory
-(PLAN §13). Both runners are green in CI during the transition.
+Two runners during the transition, both green in CI (PLAN §13):
 
-- New tests: write for `bun test`.
+- **`bun test`** — the directories listed in `apps/dokploy` `test:bun`
+- **vitest** — everything else; `__test__/vitest.config.ts` excludes the ported ones
+
+`bun run test` runs both. **Porting a directory means moving it from the vitest
+`exclude` list into the `test:bun` list** — the two must stay complementary, or
+tests silently stop running in both.
+
+- New tests: write for `bun test`, importing from `bun:test`.
 - Existing tests: leave on vitest unless you are deliberately porting that directory.
+
+Note that `bun test` will happily execute a file that imports from `"vitest"` — so a
+directory can appear ported when it is not. Rewrite the imports to `bun:test` as part
+of the port, so the runner is visible in the file.
 
 When porting, `vi.mock` → `mock.module` is **not** a rename. `vi.mock` is hoisted
 above imports; `mock.module` is not, so a module already imported at the top of the

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The migration is [planned in nine phases](docs/bun-migration/PLAN.md). **Four ar
 | 5 | Native APIs — `Bun.Terminal` ✅ done, `Bun.password`/`Bun.sql` pending | 🟡 partial |
 | 6 | Dependency cleanup | ⬜ |
 | 7 | Docker + CI | ⬜ |
-| 9 | Tests: vitest → `bun test`, gradually | ⬜ |
+| 9 | Tests: vitest → `bun test`, gradually | 🟡 18 of 96 files ported |
 
 > **The web app now runs on Bun**, in production and in dev — verified against a real
 > database, with SSR, tRPC and WebSockets all responding. There are still no runtime
@@ -58,6 +58,10 @@ The migration is [planned in nine phases](docs/bun-migration/PLAN.md). **Four ar
 **All 874 tests pass on Bun in CI** — deploys, traefik, SSH, docker, compose, backups,
 permissions. This is the single most useful data point so far, and it is stronger than
 any timing number.
+
+18 of those files now run on `bun test` rather than vitest (193 tests). The rest stay on
+vitest until ported; `bun run test` runs both, and the two scopes are kept complementary
+so nothing silently stops running.
 
 ### The application runs on Bun, end to end
 

--- a/apps/dokploy/__test__/api/api-key-name.test.ts
+++ b/apps/dokploy/__test__/api/api-key-name.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "bun:test";
 import { API_KEY_NAME_MAX_LENGTH, apiKeyNameSchema } from "@/lib/api-keys";
 
 describe("apiKeyNameSchema", () => {

--- a/apps/dokploy/__test__/api/session-management.test.ts
+++ b/apps/dokploy/__test__/api/session-management.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "bun:test";
 import { z } from "zod";
 
 const revokeSessionSchema = z.object({

--- a/apps/dokploy/__test__/backups/db-backup-restore-injection.test.ts
+++ b/apps/dokploy/__test__/backups/db-backup-restore-injection.test.ts
@@ -13,7 +13,7 @@ import {
 	getMysqlRestoreCommand,
 	getPostgresRestoreCommand,
 } from "@dokploy/server/utils/restore/utils";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 
 // A stub replacing the real `docker` binary. It ignores exec/-i/$CONTAINER_ID,
 // exports the -e VAR=val pairs, and runs the inner `sh -c <script>` — so the

--- a/apps/dokploy/__test__/backups/redact-credentials.test.ts
+++ b/apps/dokploy/__test__/backups/redact-credentials.test.ts
@@ -1,5 +1,5 @@
 import { redactRcloneCredentials } from "@dokploy/server/utils/backups/redact";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "bun:test";
 
 describe("redactRcloneCredentials (#4621)", () => {
 	it("should redact access key in rclone command", () => {

--- a/apps/dokploy/__test__/backups/restore-use-statement.test.ts
+++ b/apps/dokploy/__test__/backups/restore-use-statement.test.ts
@@ -3,7 +3,7 @@ import {
 	getRestoreCommand,
 	stripDatabaseSwitchCommand,
 } from "@dokploy/server/utils/restore/utils";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "bun:test";
 
 const filter = (input: string) =>
 	execSync(stripDatabaseSwitchCommand, {

--- a/apps/dokploy/__test__/cluster/registry-node-injection.test.ts
+++ b/apps/dokploy/__test__/cluster/registry-node-injection.test.ts
@@ -2,7 +2,7 @@ import { execSync } from "node:child_process";
 import { existsSync, rmSync } from "node:fs";
 import { getRegistryTag } from "@dokploy/server/utils/cluster/upload";
 import { parse, quote } from "shell-quote";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "bun:test";
 
 const MARK = `/tmp/dokploy_regnode_pwned_${process.pid}`;
 

--- a/apps/dokploy/__test__/cluster/upload.test.ts
+++ b/apps/dokploy/__test__/cluster/upload.test.ts
@@ -1,6 +1,6 @@
 import type { Registry } from "@dokploy/server";
 import { getRegistryTag } from "@dokploy/server";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "bun:test";
 
 describe("getRegistryTag", () => {
 	// Helper to create a mock registry

--- a/apps/dokploy/__test__/logs/log-classification.test.ts
+++ b/apps/dokploy/__test__/logs/log-classification.test.ts
@@ -1,5 +1,5 @@
 import { getLogType } from "@/components/dashboard/docker/logs/utils";
-import { expect, test } from "vitest";
+import { expect, test } from "bun:test";
 
 test("classifies real failures as error", () => {
 	expect(getLogType("Error: connection refused at db:5432").type).toBe("error");

--- a/apps/dokploy/__test__/registry/registry-schema.test.ts
+++ b/apps/dokploy/__test__/registry/registry-schema.test.ts
@@ -1,5 +1,5 @@
 import { apiCreateRegistry, apiTestRegistry } from "@dokploy/server/db/schema";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "bun:test";
 
 describe("Registry Schema - Username case preservation (#4632)", () => {
 	const validBase = {

--- a/apps/dokploy/__test__/requests/request.test.ts
+++ b/apps/dokploy/__test__/requests/request.test.ts
@@ -1,5 +1,5 @@
 import { parseRawConfig, processLogs } from "@dokploy/server";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "bun:test";
 
 const sampleLogEntry = `{"ClientAddr":"172.19.0.1:56732","ClientHost":"172.19.0.1","ClientPort":"56732","ClientUsername":"-","DownstreamContentSize":0,"DownstreamStatus":304,"Duration":14729375,"OriginContentSize":0,"OriginDuration":14051833,"OriginStatus":304,"Overhead":677542,"RequestAddr":"s222-umami-c381af.traefik.me","RequestContentSize":0,"RequestCount":122,"RequestHost":"s222-umami-c381af.traefik.me","RequestMethod":"GET","RequestPath":"/dashboard?_rsc=1rugv","RequestPort":"-","RequestProtocol":"HTTP/1.1","RequestScheme":"http","RetryAttempts":0,"RouterName":"s222-umami-60e104-47-web@docker","ServiceAddr":"10.0.1.15:3000","ServiceName":"s222-umami-60e104-47-web@docker","ServiceURL":{"Scheme":"http","Opaque":"","User":null,"Host":"10.0.1.15:3000","Path":"","RawPath":"","ForceQuery":false,"RawQuery":"","Fragment":"","RawFragment":""},"StartLocal":"2024-08-25T04:34:37.306691884Z","StartUTC":"2024-08-25T04:34:37.306691884Z","entryPointName":"web","level":"info","msg":"","time":"2024-08-25T04:34:37Z"}`;
 

--- a/apps/dokploy/__test__/services/overview-backups-icon.test.ts
+++ b/apps/dokploy/__test__/services/overview-backups-icon.test.ts
@@ -2,7 +2,7 @@ import {
 	getBackupOverviewIcon,
 	getServiceOverviewIcon,
 } from "@dokploy/server/services/overview";
-import { describe, expect, test } from "vitest";
+import { describe, expect, test } from "bun:test";
 
 describe("getServiceOverviewIcon", () => {
 	test("returns a db icon for every known DB engine type", () => {

--- a/apps/dokploy/__test__/services/overview-domains-sort.test.ts
+++ b/apps/dokploy/__test__/services/overview-domains-sort.test.ts
@@ -1,6 +1,6 @@
 import type { OverviewDomain } from "@dokploy/server/services/overview";
 import { sortOverviewDomains } from "@dokploy/server/services/overview";
-import { describe, expect, test } from "vitest";
+import { describe, expect, test } from "bun:test";
 
 const makeDomain = (overrides: Partial<OverviewDomain>): OverviewDomain => ({
 	domainId: "id",

--- a/apps/dokploy/__test__/services/overview-services-sort.test.ts
+++ b/apps/dokploy/__test__/services/overview-services-sort.test.ts
@@ -1,6 +1,6 @@
 import type { OverviewService } from "@dokploy/server/services/overview";
 import { sortOverviewServices } from "@dokploy/server/services/overview";
-import { describe, expect, test } from "vitest";
+import { describe, expect, test } from "bun:test";
 
 const makeService = (overrides: Partial<OverviewService>): OverviewService => ({
 	id: "id",

--- a/apps/dokploy/__test__/templates/config.template.test.ts
+++ b/apps/dokploy/__test__/templates/config.template.test.ts
@@ -1,7 +1,7 @@
 import type { Schema } from "@dokploy/server/templates";
 import type { CompleteTemplate } from "@dokploy/server/templates/processors";
 import { processTemplate } from "@dokploy/server/templates/processors";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "bun:test";
 
 describe("processTemplate", () => {
 	// Mock schema for testing

--- a/apps/dokploy/__test__/templates/helpers.template.test.ts
+++ b/apps/dokploy/__test__/templates/helpers.template.test.ts
@@ -1,6 +1,6 @@
 import type { Schema } from "@dokploy/server/templates";
 import { processValue } from "@dokploy/server/templates/processors";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "bun:test";
 
 describe("helpers functions", () => {
 	// Mock schema for testing

--- a/apps/dokploy/__test__/utils/backups.test.ts
+++ b/apps/dokploy/__test__/utils/backups.test.ts
@@ -1,5 +1,5 @@
 import { normalizeS3Path } from "@dokploy/server/utils/backups/utils";
-import { describe, expect, test } from "vitest";
+import { describe, expect, test } from "bun:test";
 
 describe("normalizeS3Path", () => {
 	test("should handle empty and whitespace-only prefix", () => {

--- a/apps/dokploy/__test__/utils/hostname-validation.test.ts
+++ b/apps/dokploy/__test__/utils/hostname-validation.test.ts
@@ -1,5 +1,5 @@
 import { VALID_HOSTNAME_REGEX } from "@dokploy/server";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "bun:test";
 
 describe("VALID_HOSTNAME_REGEX", () => {
 	it.each([

--- a/apps/dokploy/__test__/utils/log-type.test.ts
+++ b/apps/dokploy/__test__/utils/log-type.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test } from "bun:test";
 import { getLogType } from "@/components/dashboard/docker/logs/utils";
 
 describe("getLogType", () => {

--- a/apps/dokploy/__test__/vitest.config.ts
+++ b/apps/dokploy/__test__/vitest.config.ts
@@ -5,7 +5,22 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
 	test: {
 		include: ["__test__/**/*.test.ts"], // Incluir solo los archivos de test en el directorio __test__
-		exclude: ["**/node_modules/**", "**/dist/**", "**/.docker/**"],
+		// Directories ported to `bun test` - see the test:bun script. Porting a
+		// directory means moving it from here into that script's list.
+		exclude: [
+			"**/node_modules/**",
+			"**/dist/**",
+			"**/.docker/**",
+			"**/__test__/logs/**",
+			"**/__test__/registry/**",
+			"**/__test__/requests/**",
+			"**/__test__/api/**",
+			"**/__test__/cluster/**",
+			"**/__test__/templates/**",
+			"**/__test__/backups/**",
+			"**/__test__/services/**",
+			"**/__test__/utils/**",
+		],
 		pool: "forks",
 		setupFiles: [path.resolve(__dirname, "setup.ts")],
 	},

--- a/apps/dokploy/package.json
+++ b/apps/dokploy/package.json
@@ -36,7 +36,9 @@
 		"docker:build:canary": "./docker/build.sh canary",
 		"docker:push:canary": "./docker/push.sh canary",
 		"version": "echo $(node -p \"require('./package.json').version\")",
-		"test": "vitest --config __test__/vitest.config.ts",
+		"test": "bun run test:bun && bun run test:vitest",
+		"test:bun": "bun test __test__/logs __test__/registry __test__/requests __test__/api __test__/cluster __test__/templates __test__/backups __test__/services __test__/utils",
+		"test:vitest": "vitest --config __test__/vitest.config.ts",
 		"generate:openapi": "bun scripts/generate-openapi.ts"
 	},
 	"dependencies": {


### PR DESCRIPTION
Phase 9, first batch. Nine directories — `logs`, `registry`, `requests`, `api`, `cluster`, `templates`, `backups`, `services`, `utils` — move from vitest to `bun test`. **18 files, 193 tests.**

## Why these nine

None of them use `vi.mock`. That is the entire risk in this phase: `vi.mock` is hoisted above imports and `mock.module` is not, so a mechanical rename produces **a test that passes while asserting nothing**. The directories that do use it are deliberately left alone.

## The port needed no changes beyond the import line

`bun test` implements the same `describe`/`it`/`expect` surface. Worth knowing: **`bun test` will happily run a file that still imports from `"vitest"`** — so a directory can look ported when nothing has actually moved. The imports are rewritten to `bun:test` precisely so the runner is visible in the file instead of inferred from a script.

## Verified the tests actually assert

A port that requires no code changes is exactly the kind that deserves suspicion, so:

```
# getLogType broken on purpose
1 pass, 3 fail
# restored
4 pass, 0 fail
```

They execute and they assert.

## The two runners stay complementary

`vitest.config.ts` excludes the ported directories; the `test:bun` script lists them; `bun run test` runs both. The counts confirm nothing fell between them:

| | Files | Tests |
|---|---|---|
| vitest | 78 | 681 |
| bun test | 18 | 193 |
| **total** | **96** | **874** |

Same as before the split. Porting a directory means moving it from one list to the other — noted in CLAUDE.md, because getting that wrong makes tests stop running in *both*.

## CLAUDE.md refresh

It had gone stale in four places: tests now run on two runners; `node-pty` and `bcrypt` are no longer native dependencies; `dotenv` stays for `parse()` even though it is gone as an env loader; `undici` stays for `FileList`.

Added the three things this migration learned the hard way:

- **Bun aborts an install when a trusted package's build script fails**, where pnpm tolerates it — which is why `tree-sitter` is no longer listed, and why its long-broken build only became visible now
- **`node-gyp` needs a Node binary** the `oven/bun` image does not ship
- **`pino` transports cannot survive bundling** — pass `pino-pretty` as a stream
- **`bun run x` does not put everything `x` spawns on Bun** — `next build` needs `bun --bun`

🤖 Generated with [Claude Code](https://claude.com/claude-code)