### PR TITLE
ci: publish arm64 images and stop upstream-only workflows from failing

### DIFF
--- a/.github/workflows/create-pr.yml
+++ b/.github/workflows/create-pr.yml
@@ -1,5 +1,10 @@
 name: Auto PR to main when version changes
 
+# Upstream-only: upstream's release automation, needs GH_PAT.
+# The required secrets exist in Dokploy/dokploy and not in this fork, so every job
+# is gated on the repository rather than the file being deleted - deleting it would
+# conflict on every upstream merge. See docs/FORK-STRATEGY.md.
+
 on:
   push:
     branches:
@@ -11,6 +16,7 @@ permissions:
 
 jobs:
   create-pr:
+    if: github.repository == 'Dokploy/dokploy'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,10 @@
 name: Build Docker images
 
+# Upstream-only: pushes dokploy/server and dokploy/schedule to Docker Hub, which publish-images.yml does for this fork.
+# The required secrets exist in Dokploy/dokploy and not in this fork, so every job
+# is gated on the repository rather than the file being deleted - deleting it would
+# conflict on every upstream merge. See docs/FORK-STRATEGY.md.
+
 on:
   push:
     branches: [main, canary]
@@ -7,6 +12,7 @@ on:
 
 jobs:
   build-and-push-cloud-image:
+    if: github.repository == 'Dokploy/dokploy'
     runs-on: ubuntu-latest
 
     steps:
@@ -44,6 +50,7 @@ jobs:
             NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=${{ secrets.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY }}
 
   build-and-push-schedule-image:
+    if: github.repository == 'Dokploy/dokploy'
     runs-on: ubuntu-latest
 
     steps:
@@ -76,6 +83,7 @@ jobs:
           platforms: linux/amd64
 
   build-and-push-server-image:
+    if: github.repository == 'Dokploy/dokploy'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/dokploy.yml
+++ b/.github/workflows/dokploy.yml
@@ -99,6 +99,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
 
   combine-manifests:
+    if: github.repository == 'Dokploy/dokploy'
     needs: [docker-amd, docker-arm]
     runs-on: ubuntu-latest
     steps:
@@ -142,8 +143,8 @@ jobs:
           fi
 
   generate-release:
+    if: github.repository == 'Dokploy/dokploy' && github.ref == 'refs/heads/main'
     needs: [combine-manifests]
-    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.get_version.outputs.version }}
@@ -183,8 +184,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   sync-version:
+    if: github.repository == 'Dokploy/dokploy' && github.ref == 'refs/heads/main'
     needs: [generate-release]
-    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/hotfix-cherry-pick.yml
+++ b/.github/workflows/hotfix-cherry-pick.yml
@@ -1,5 +1,10 @@
 name: Hotfix Cherry-Pick
 
+# Upstream-only: upstream's hotfix process, needs HOTFIX_PUSH_TOKEN.
+# The required secrets exist in Dokploy/dokploy and not in this fork, so every job
+# is gated on the repository rather than the file being deleted - deleting it would
+# conflict on every upstream merge. See docs/FORK-STRATEGY.md.
+
 on:
   pull_request_target:
     types: [closed, labeled]
@@ -10,7 +15,7 @@ concurrency:
 
 jobs:
   cherry-pick:
-    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'hotfix')
+    if: github.repository == 'Dokploy/dokploy' && github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'hotfix')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/hotfix-release.yml
+++ b/.github/workflows/hotfix-release.yml
@@ -1,5 +1,10 @@
 name: Hotfix Release
 
+# Upstream-only: upstream's hotfix process, needs HOTFIX_PUSH_TOKEN.
+# The required secrets exist in Dokploy/dokploy and not in this fork, so every job
+# is gated on the repository rather than the file being deleted - deleting it would
+# conflict on every upstream merge. See docs/FORK-STRATEGY.md.
+
 on:
   workflow_dispatch:
 
@@ -9,6 +14,7 @@ concurrency:
 
 jobs:
   release:
+    if: github.repository == 'Dokploy/dokploy'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main

--- a/.github/workflows/monitoring.yml
+++ b/.github/workflows/monitoring.yml
@@ -1,5 +1,10 @@
 name: Dokploy Monitoring Build
 
+# Upstream-only: pushes dokploy/monitoring, the Go service, to Docker Hub.
+# The required secrets exist in Dokploy/dokploy and not in this fork, so every job
+# is gated on the repository rather than the file being deleted - deleting it would
+# conflict on every upstream merge. See docs/FORK-STRATEGY.md.
+
 on:
   push:
     branches: [main, canary]
@@ -9,6 +14,7 @@ env:
 
 jobs:
   docker-amd:
+    if: github.repository == 'Dokploy/dokploy'
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -44,6 +50,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
   docker-arm:
+    if: github.repository == 'Dokploy/dokploy'
     runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
@@ -80,6 +87,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
 
   combine-manifests:
+    if: github.repository == 'Dokploy/dokploy'
     needs: [docker-amd, docker-arm]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,10 +1,14 @@
 name: Publish images
 
 # Builds and publishes this fork's images to its own GitHub Container Registry.
-# Upstream's dokploy.yml pushes to Docker Hub under dokploy/* with secrets this
-# fork does not have, so it is disabled here (see the guard in that file).
 #
-# GHCR authenticates with the built-in GITHUB_TOKEN - no secrets to configure.
+# Upstream's dokploy.yml and deploy.yml push to Docker Hub under dokploy/* with
+# secrets this fork does not have; both are gated to the upstream repository.
+# GHCR authenticates with the built-in GITHUB_TOKEN, so there is nothing to set up.
+#
+# amd64 and arm64 are built on native runners rather than under QEMU: the web
+# image runs a full `next build`, and emulating that is slow enough to time out.
+# arm64 matters here - a Raspberry Pi 5 is arm64, as are Ampere/Graviton VPSes.
 
 on:
   push:
@@ -13,24 +17,23 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - dockerfile: Dockerfile
-            suffix: ""
-          - dockerfile: Dockerfile.server
-            suffix: "-api"
-          - dockerfile: Dockerfile.schedule
-            suffix: "-schedules"
+        image:
+          - { dockerfile: Dockerfile, suffix: "" }
+          - { dockerfile: Dockerfile.server, suffix: "-api" }
+          - { dockerfile: Dockerfile.schedule, suffix: "-schedules" }
+        platform:
+          - { arch: amd64, runner: ubuntu-latest }
+          - { arch: arm64, runner: ubuntu-24.04-arm }
+    runs-on: ${{ matrix.platform.runner }}
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v5
 
@@ -43,30 +46,57 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Resolve tag
+      - name: Resolve image and tag
         id: meta
         run: |
           # GHCR requires a lowercase image path
-          image="$(echo "${REGISTRY}/${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')${{ matrix.suffix }}"
-          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            tag="latest"
-          else
-            tag="canary"
-          fi
-          echo "tags=${image}:${tag},${image}:${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          image="$(echo "${REGISTRY}/${{ github.repository }}" | tr '[:upper:]' '[:lower:]')${{ matrix.image.suffix }}"
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then tag="latest"; else tag="canary"; fi
+          echo "image=$image" >> "$GITHUB_OUTPUT"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
       - name: Prepare env file
         run: |
           cp apps/dokploy/.env.production.example .env.production
           cp apps/dokploy/.env.production.example apps/dokploy/.env.production
 
-      - name: Build and push
+      - name: Build and push (${{ matrix.platform.arch }})
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: ${{ matrix.dockerfile }}
-          platforms: linux/amd64
+          file: ${{ matrix.image.dockerfile }}
+          platforms: linux/${{ matrix.platform.arch }}
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          tags: ${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.tag }}-${{ matrix.platform.arch }}
+          cache-from: type=gha,scope=${{ matrix.image.suffix }}-${{ matrix.platform.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image.suffix }}-${{ matrix.platform.arch }}
+
+  manifest:
+    # Combines the per-arch tags into one multi-arch tag, so `docker pull` picks
+    # the right architecture automatically.
+    needs: [build]
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    strategy:
+      matrix:
+        suffix: ["", "-api", "-schedules"]
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push manifest
+        run: |
+          image="$(echo "${REGISTRY}/${{ github.repository }}" | tr '[:upper:]' '[:lower:]')${{ matrix.suffix }}"
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then tag="latest"; else tag="canary"; fi
+          docker buildx imagetools create -t "${image}:${tag}" \
+            "${image}:${tag}-amd64" \
+            "${image}:${tag}-arm64"
+          docker buildx imagetools create -t "${image}:${{ github.sha }}" \
+            "${image}:${tag}-amd64" \
+            "${image}:${tag}-arm64"
+          echo "Published ${image}:${tag} (amd64 + arm64)"

--- a/.github/workflows/sync-openapi-docs.yml
+++ b/.github/workflows/sync-openapi-docs.yml
@@ -1,5 +1,10 @@
 name: Generate and Sync OpenAPI
 
+# Upstream-only: writes into upstream's docs repository, needs DOCS_SYNC_TOKEN.
+# The required secrets exist in Dokploy/dokploy and not in this fork, so every job
+# is gated on the repository rather than the file being deleted - deleting it would
+# conflict on every upstream merge. See docs/FORK-STRATEGY.md.
+
 on:
   push:
     branches:
@@ -14,6 +19,7 @@ on:
 
 jobs:
   generate-and-commit:
+    if: github.repository == 'Dokploy/dokploy'
     name: Generate OpenAPI and commit to Dokploy repo
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -215,9 +215,21 @@ To update an existing install:
 curl -sSL https://raw.githubusercontent.com/SashaGoncharov19/dokploy-bun/canary/install.sh | sh -s update
 ```
 
+### Architectures
+
+Images are published for **`linux/amd64` and `linux/arm64`**, built on native runners
+rather than under emulation. `docker pull` picks the right one, so a **Raspberry Pi 5**,
+an Ampere or Graviton VPS and an ordinary x86 box all use the same command.
+
+arm64 is not a guess: every image in this repository was first built and run on arm64
+(Apple Silicon) before any of it reached CI, including the docker CLI, nixpacks,
+railpack and buildpacks layers.
+
 ⚠️ **This installs a PaaS that manages Docker on the host.** It initialises Docker
-Swarm, creates an overlay network and writes to `/etc/dokploy`. Run it on a machine
-you intend to dedicate to it, not your laptop.
+Swarm, creates an overlay network and writes to `/etc/dokploy`. Run it on a machine you
+intend to dedicate to it, not your laptop. On a Pi that means an SSD rather than an SD
+card — deployments do a lot of disk I/O — and 8GB of RAM is a comfortable floor once
+Postgres, Traefik and your own containers are running.
 
 ## Working on it
 


### PR DESCRIPTION
Two problems on `canary`: every push produced three red workflows, and the images being published were **amd64-only**.

## arm64 — the one that actually blocks you

`publish-images.yml` built only `linux/amd64`, so the published images **cannot run on a Raspberry Pi 5**, or on Ampere/Graviton hosts. GHCR confirms it:

```
"platform": { "architecture": "amd64", "os": "linux" }
```

It now builds **both architectures on native runners** — `ubuntu-latest` and `ubuntu-24.04-arm` — and a second job combines the per-arch tags into one multi-arch tag, so `docker pull` resolves the right image by itself. Native runners rather than QEMU because the web image runs a full `next build`, and emulating that is slow enough to time out.

**arm64 itself was never in doubt.** Every image in this repository was built and run on arm64 (Apple Silicon) during phase 7 before any of it reached CI — docker CLI, nixpacks, railpack and buildpacks layers included:

```
local api image arch:  arm64 linux
local main image arch: arm64 linux
```

Only the *publishing* was missing.

## The three red workflows

Six workflows inherited from upstream need secrets that exist in `Dokploy/dokploy` and not here — `DOCKERHUB_*`, `GH_PAT`, `HOTFIX_PUSH_TOKEN`, `DOCS_SYNC_TOKEN` — so every push produced failures that mean nothing:

| Workflow | What it does | Why not ours |
|---|---|---|
| `deploy.yml` | pushes `dokploy/server`, `dokploy/schedule` to Docker Hub | `publish-images.yml` already does this for the fork |
| `monitoring.yml` | pushes `dokploy/monitoring` (the Go service) | upstream's image |
| `create-pr.yml` | release automation | needs `GH_PAT` |
| `hotfix-cherry-pick.yml`, `hotfix-release.yml` | upstream's hotfix process | needs `HOTFIX_PUSH_TOKEN` |
| `sync-openapi-docs.yml` | writes into upstream's docs repo | not ours to write to |

Every job in all six is gated on `github.repository == 'Dokploy/dokploy'`. Also finished the job for `dokploy.yml` — three of its five jobs were relying on `needs` chaining, which does work but is implicit.

**Gated rather than deleted**, per [FORK-STRATEGY.md](docs/FORK-STRATEGY.md): deleting an upstream file means conflicting on it at every future merge, and these cost one line each to neutralise.

## One thing worth flagging

Where a job already had an `if:`, the conditions are merged with `&&` rather than a second key being added. My first pass did add a second key — **three jobs would have been silently invalid YAML**, and a `grep -c` guard count showed them as correct. Caught by actually parsing every file:

```
create-pr.yml         VALID  jobs=1  guarded=1
deploy.yml            VALID  jobs=3  guarded=3
dokploy.yml           VALID  jobs=5  guarded=5
format.yml            VALID  jobs=1  guarded=0
hotfix-cherry-pick    VALID  jobs=1  guarded=1
hotfix-release.yml    VALID  jobs=1  guarded=1
monitoring.yml        VALID  jobs=3  guarded=3
publish-images.yml    VALID  jobs=2  guarded=0
pull-request.yml      VALID  jobs=1  guarded=0
sync-openapi-docs     VALID  jobs=1  guarded=1
```

16 gated jobs across the upstream workflows; zero gates on the three that are ours.

## README

Adds an architectures section, and Raspberry Pi specifics worth knowing before you start: SSD rather than SD card, since deployments do a lot of disk I/O, and 8GB RAM as a comfortable floor once Postgres, Traefik and your own containers are running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)