### PR TITLE
fix(install): fall back to canary, not a tag that does not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,11 +203,15 @@ On a fresh VPS, as root:
 curl -sSL https://raw.githubusercontent.com/SashaGoncharov19/dokploy-bun/canary/install.sh | sh
 ```
 
-The script is upstream's, changed in exactly two ways: images come from this
-repository's GitHub Container Registry (`ghcr.io/sashagoncharov19/dokploy-bun`)
-rather than Docker Hub, and version detection follows **this** repository's
-releases. Both are overridable — `DOKPLOY_IMAGE` and `DOKPLOY_REPO` — if you build
-your own.
+The script is upstream's, changed in three ways: images come from this repository's
+GitHub Container Registry (`ghcr.io/sashagoncharov19/dokploy-bun`) rather than Docker
+Hub, version detection follows **this** repository's releases, and when there is no
+release to detect it falls back to `canary` rather than `latest`. All three are
+overridable — `DOKPLOY_IMAGE`, `DOKPLOY_REPO`, `DOKPLOY_FALLBACK_VERSION`.
+
+There are no tagged releases yet, so installs land on `canary`, which is what
+`publish-images.yml` publishes. Pin explicitly with `DOKPLOY_VERSION=canary` if you
+prefer to be sure.
 
 To update an existing install:
 

--- a/install.sh
+++ b/install.sh
@@ -9,6 +9,9 @@ DOCKER_VERSION="28.5.0"
 # with DOKPLOY_IMAGE / DOKPLOY_REPO if you host your own build.
 DOKPLOY_REPO="${DOKPLOY_REPO:-SashaGoncharov19/dokploy-bun}"
 DOKPLOY_IMAGE="${DOKPLOY_IMAGE:-ghcr.io/sashagoncharov19/dokploy-bun}"
+# Used when no GitHub release can be detected. canary is what publish-images.yml
+# pushes today; this becomes "latest" once the fork cuts its first release.
+DOKPLOY_FALLBACK_VERSION="${DOKPLOY_FALLBACK_VERSION:-canary}"
 
 # Detect version from environment variable or default to latest
 # Usage with curl (export first): export DOKPLOY_VERSION=canary && curl -sSL https://raw.githubusercontent.com/SashaGoncharov19/dokploy-bun/canary/install.sh | sh
@@ -39,10 +42,13 @@ detect_version() {
             *) version="" ;;
         esac
 
-        # Fallback to latest tag if detection fails
+        # Fallback if detection fails. Upstream falls back to "latest", which is
+        # published from its main branch. This fork publishes from canary and has
+        # no tagged releases yet, so "latest" does not exist and the install dies
+        # with "No such image". Fall back to the tag that is actually there.
         if [ -z "$version" ]; then
-            echo "Warning: Could not detect latest version from GitHub, using fallback version latest" >&2
-            version="latest"
+            echo "Warning: no release detected in ${DOKPLOY_REPO}, falling back to ${DOKPLOY_FALLBACK_VERSION}" >&2
+            version="${DOKPLOY_FALLBACK_VERSION}"
         else
             echo "Latest stable version detected: $version" >&2
         fi


### PR DESCRIPTION
Installing on a fresh arm64 host failed at the last step:

```
Warning: Could not detect latest version from GitHub, using fallback version latest
...
1/1: No such image: ghcr.io/sashagoncharov19/dokploy-bun:latest
```

**Everything up to that point worked** — Docker installed, swarm initialised, Proxmox LXC detected and handled, secrets generated, Postgres converged 1/1. Only the image pull had nowhere to go.

## Cause

Upstream falls back to `latest` because that is what its `main` branch publishes. This fork publishes from `canary` and has **no tagged releases**, so `latest` is a 404. Confirmed against the registry rather than inferred:

```
tags: canary, canary-amd64, canary-arm64, <per-commit sha tags>
latest -> HTTP 404
```

## Fix

The fallback is now `DOKPLOY_FALLBACK_VERSION`, defaulting to `canary`, and the warning names the repository it searched instead of just announcing a version. It becomes `latest` on its own once this fork cuts a release, because detection succeeds before the fallback is reached.

## Immediate workaround for anyone already stuck

```bash
docker service rm dokploy
DOKPLOY_VERSION=canary curl -sSL https://raw.githubusercontent.com/SashaGoncharov19/dokploy-bun/canary/install.sh | sh
```

## Verified

`detect_version` run against the real repository now returns `canary`, and the script still passes `sh -n` and `bash -n`.

Separately confirmed the published image is genuinely usable: pulled `ghcr.io/sashagoncharov19/dokploy-bun:canary` anonymously, got **arm64**, ran it against a real Postgres — container reports **healthy**, `/api/trpc/settings.health` 200, `/register` 200 with 32KB of SSR HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)