### PR TITLE
feat(install): refuse to install over an existing database instead of failing later

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,10 +213,20 @@ There are no tagged releases yet, so installs land on `canary`, which is what
 `publish-images.yml` publishes. Pin explicitly with `DOKPLOY_VERSION=canary` if you
 prefer to be sure.
 
-To update an existing install:
+To update an existing install, keeping your data:
 
 ```bash
 curl -sSL https://raw.githubusercontent.com/SashaGoncharov19/dokploy-bun/canary/install.sh | sh -s update
+```
+
+Re-running the **full** install over an existing database is refused, with instructions,
+rather than failing later: a full install generates a new Postgres password, but Postgres
+keeps the one it was first initialised with, so the app would start and then fail
+authentication. To wipe and start clean — **this destroys all Dokploy data**:
+
+```bash
+export DOKPLOY_RESET_DB=true
+curl -sSL https://raw.githubusercontent.com/SashaGoncharov19/dokploy-bun/canary/install.sh | sh
 ```
 
 ### Architectures

--- a/install.sh
+++ b/install.sh
@@ -12,6 +12,7 @@ DOKPLOY_IMAGE="${DOKPLOY_IMAGE:-ghcr.io/sashagoncharov19/dokploy-bun}"
 # Used when no GitHub release can be detected. canary is what publish-images.yml
 # pushes today; this becomes "latest" once the fork cuts its first release.
 DOKPLOY_FALLBACK_VERSION="${DOKPLOY_FALLBACK_VERSION:-canary}"
+DOKPLOY_INSTALL_URL="${DOKPLOY_INSTALL_URL:-https://raw.githubusercontent.com/SashaGoncharov19/dokploy-bun/canary/install.sh}"
 
 # Detect version from environment variable or default to latest
 # Usage with curl (export first): export DOKPLOY_VERSION=canary && curl -sSL https://raw.githubusercontent.com/SashaGoncharov19/dokploy-bun/canary/install.sh | sh
@@ -103,6 +104,57 @@ generate_random_password() {
     echo "$password"
 }
 
+# A full install regenerates the Postgres password: `docker swarm leave` below
+# destroys every Docker Secret, and a fresh one is created further down. The
+# dokploy-postgres volume survives both, and Postgres only applies
+# POSTGRES_PASSWORD when it initialises an *empty* data directory - so installing
+# over an existing volume authenticates with a password the database has never
+# seen:
+#
+#     FATAL: password authentication failed for user "dokploy"  (28P01)
+#
+# The service then sits in "Starting" indefinitely, and `docker service logs`
+# shows nothing, because the failure is inside the container rather than in
+# swarm. Fail here instead, where the cause is still obvious.
+check_existing_database() {
+    if ! docker volume inspect dokploy-postgres >/dev/null 2>&1; then
+        return 0
+    fi
+
+    if [ "${DOKPLOY_RESET_DB}" = "true" ]; then
+        echo "DOKPLOY_RESET_DB=true - removing the existing database volume."
+        docker service rm dokploy dokploy-postgres >/dev/null 2>&1 || true
+        i=0
+        while [ "$i" -lt 30 ]; do
+            docker volume rm dokploy-postgres >/dev/null 2>&1 && break
+            i=$((i + 1))
+            sleep 1
+        done
+        if docker volume inspect dokploy-postgres >/dev/null 2>&1; then
+            echo "Error: could not remove the dokploy-postgres volume - something is still using it." >&2
+            echo "Stop it and retry:  docker service rm dokploy dokploy-postgres && docker volume rm dokploy-postgres" >&2
+            exit 1
+        fi
+        echo "Existing database removed. Continuing with a clean install."
+        return 0
+    fi
+
+    echo "" >&2
+    echo "An existing Dokploy database was found (docker volume: dokploy-postgres)." >&2
+    echo "" >&2
+    echo "A full install generates a new database password, but Postgres keeps the one" >&2
+    echo "it was first initialised with - so this install would fail to authenticate." >&2
+    echo "" >&2
+    echo "  To upgrade and keep your data:" >&2
+    echo "    curl -sSL ${DOKPLOY_INSTALL_URL} | sh -s update" >&2
+    echo "" >&2
+    echo "  To wipe the database and install from scratch (DESTROYS ALL DOKPLOY DATA):" >&2
+    echo "    export DOKPLOY_RESET_DB=true" >&2
+    echo "    curl -sSL ${DOKPLOY_INSTALL_URL} | sh" >&2
+    echo "" >&2
+    exit 1
+}
+
 install_dokploy() {
     # Detect version tag
     VERSION_TAG=$(detect_version)
@@ -176,6 +228,8 @@ install_dokploy() {
         sleep 5
     fi
 
+
+    check_existing_database
 
     docker swarm leave --force 2>/dev/null
 

--- a/install.sh
+++ b/install.sh
@@ -124,8 +124,17 @@ check_existing_database() {
     if [ "${DOKPLOY_RESET_DB}" = "true" ]; then
         echo "DOKPLOY_RESET_DB=true - removing the existing database volume."
         docker service rm dokploy dokploy-postgres >/dev/null 2>&1 || true
+
+        # Removing the services is not enough: their stopped containers keep a
+        # reference to the volume, and `docker volume rm` then reports
+        # "volume is in use" for a container that is not even running.
         i=0
         while [ "$i" -lt 30 ]; do
+            holders=$(docker ps -aq --filter volume=dokploy-postgres 2>/dev/null)
+            if [ -n "$holders" ]; then
+                # shellcheck disable=SC2086
+                docker rm -f $holders >/dev/null 2>&1 || true
+            fi
             docker volume rm dokploy-postgres >/dev/null 2>&1 && break
             i=$((i + 1))
             sleep 1


### PR DESCRIPTION
Re-running the full installer produced a service stuck in `Starting` with **no service-level logs at all**. The container logs had the real cause:

```
FATAL: password authentication failed for user "dokploy"  (28P01)
```

## Why

A full install regenerates credentials: `docker swarm leave` destroys every Docker Secret, and a fresh Postgres password is created further down. The `dokploy-postgres` **volume survives both** — and Postgres only applies `POSTGRES_PASSWORD` when it initialises an *empty* data directory.

So the app authenticates with a password the database has never seen. Guaranteed, every time, on any re-install.

The failure is also close to undiagnosable from the outside: swarm reports `Starting`, `docker service ps` shows no ERROR, and `docker service logs` returns nothing. Only `docker logs` on the container itself shows it.

## Fix

`check_existing_database` runs **before the swarm is torn down**, while the situation is still detectable, and either stops with both ways forward or clears the volume on request.

Default — refuses and explains:

```
An existing Dokploy database was found (docker volume: dokploy-postgres).

A full install generates a new database password, but Postgres keeps the one
it was first initialised with - so this install would fail to authenticate.

  To upgrade and keep your data:
    curl -sSL .../install.sh | sh -s update

  To wipe the database and install from scratch (DESTROYS ALL DOKPLOY DATA):
    export DOKPLOY_RESET_DB=true
    curl -sSL .../install.sh | sh
```

It points at `sh -s update` first, because that is what people usually want — upgrading without losing data — and that path leaves secrets alone.

## Verified against real Docker volumes

| Case | Result |
|---|---|
| no volume | continues silently, exit 0 |
| volume, no flag | exits 1 with the guidance above |
| volume + `DOKPLOY_RESET_DB=true` | removes the volume, continues, volume confirmed gone |

Script still passes `sh -n` and `bash -n`.

## Note

This is **upstream behaviour**, not something the Bun migration introduced — the installer has always regenerated secrets without touching the volume. It just is not visible until it bites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)