### PR TITLE
docs: record the production verification on arm64

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ The migration is [planned in nine phases](docs/bun-migration/PLAN.md). **Four ar
 | 7 | Docker + CI | ⬜ |
 | 9 | Tests: vitest → `bun test`, gradually | 🟡 18 of 96 files ported |
 
+**Verified running in production** on a Raspberry-class arm64 host — see below.
+
 > **The web app now runs on Bun**, in production and in dev — verified against a real
 > database, with SSR, tRPC and WebSockets all responding. There are still no runtime
 > *performance* numbers; nothing has run under real load.
@@ -62,6 +64,33 @@ any timing number.
 18 of those files now run on `bun test` rather than vitest (193 tests). The rest stay on
 vitest until ported; `bun run test` runs both, and the two scopes are kept complementary
 so nothing silently stops running.
+
+### It runs in production on arm64
+
+Not a benchmark — a real instance, installed with the install script on Debian 13
+(arm64, Proxmox LXC), deploying and serving real containers. Every one of the six
+WebSocket servers was exercised by hand:
+
+| Feature | Mechanism | |
+|---|---|---|
+| Container terminal | **`Bun.Terminal`** | ✅ interactive session, commands execute |
+| Container logs | **`Bun.Terminal`** | ✅ live `docker logs --follow` stream |
+| Server terminal | `ssh2` | ✅ interactive shell |
+| Deployment console | `ssh2` | ✅ live build output |
+| Monitoring / stats | `dockerode` | ✅ |
+| Drawer logs | — | ✅ |
+
+Plus: registration (which exercises `Bun.password` **and** `Bun.sql` on the write path),
+the full migration chain applied on first boot, and a three-image Docker Compose stack
+deployed end to end.
+
+**The terminal is the result that matters.** `node-pty` under Bun dies ~8ms after spawn
+and throws `EBADF` on `resize()`. The `Bun.Terminal` replacement holds a session, runs
+commands, and `stty size` tracks the width as the browser window is resized — confirmed
+on real ARM hardware rather than in a spike.
+
+*(Row count stays fixed because the terminal panel is `h-[420px]` in the UI, not because
+resize fails — width changes prove the resize messages reach the PTY.)*
 
 ### The application runs on Bun, end to end
 
@@ -181,11 +210,12 @@ seconds saved.
 
 Stated plainly, because a benchmark table that omits its gaps is not worth reading:
 
-- **No runtime performance data.** The server runs on Bun now, but nothing here measures
-  request latency, throughput, or memory against Node.
-- **No production evidence.** No instance has run under sustained real load.
-- **No Docker image comparison.** Image size and cold-boot time come with phase 7.
-- **`node_modules` did not shrink.** 1.5G before, 1.5G after.
+- **No runtime performance data.** The server runs on Bun and is verified working, but
+  nothing here measures request latency, throughput, or memory against Node.
+- **No sustained-load evidence.** The instance above works; it has not been run under
+  production traffic for a meaningful period, and nothing here is a stability claim.
+- **`node_modules` did not shrink.** 1.5G before, 1.5G after. The service *images* did —
+  see above — but that is bundling, not the dependency tree.
 
 ## Known broken
 

--- a/docs/bun-migration/SPIKE-RESULTS.md
+++ b/docs/bun-migration/SPIKE-RESULTS.md
@@ -233,6 +233,62 @@ runner while Next itself executes on Node (`bun --bun` forces otherwise). A cust
 that imports `next()` in-process, as Dokploy does, genuinely runs Next inside Bun — which
 is why this hit us and does not hit those templates.
 
+### Production verification on arm64
+
+Everything above is a spike or a CI run. This is the instance: installed with
+`install.sh` on Debian 13 (arm64, Proxmox LXC, 8GB), pulling the published multi-arch
+image from GHCR anonymously, deploying and serving real containers.
+
+All six WebSocket servers exercised by hand:
+
+| Endpoint | Mechanism | Result |
+|---|---|---|
+| `docker-container-terminal` | **Bun.Terminal** | interactive session, commands execute |
+| `docker-container-logs` | **Bun.Terminal** | live `docker logs --follow` stream |
+| `terminal` | ssh2 | interactive shell |
+| `listen-deployment` | ssh2 | live build output |
+| `docker-stats` | dockerode | live stats |
+| `drawer-logs` | — | works |
+
+`Bun.Terminal` is the one that mattered. Resize was confirmed by `stty size` inside the
+container while resizing the browser: `18 127` → `18 71` → `18 38`. The column count
+tracks the window, which proves the resize messages reach the PTY. The row count does
+not, because `docker-terminal.tsx:122` pins the panel at `h-[420px]` — a UI layout
+choice, unrelated to the runtime.
+
+Also verified: registration (exercising `Bun.password` and `Bun.sql` on the write path),
+the migration chain applying on first boot, and a three-image Compose stack deployed end
+to end.
+
+### Two installer traps found by installing for real
+
+Neither is caused by the Bun migration; both are upstream behaviour that only appears on
+a second install, and both are now handled in `install.sh`.
+
+**No `:latest` tag.** Version detection falls back to `latest`, which upstream publishes
+from `main`. This fork publishes from `canary` and has no releases, so the tag 404s and
+the service sits in `Starting` with `No such image`. The fallback is now
+`DOKPLOY_FALLBACK_VERSION`, defaulting to `canary`.
+
+**Stale database volume.** A full install runs `docker swarm leave`, which destroys every
+Docker Secret, then generates a new Postgres password — but the `dokploy-postgres` volume
+survives, and Postgres only applies `POSTGRES_PASSWORD` when initialising an empty data
+directory. The result is `FATAL: password authentication failed (28P01)`, invisible from
+`docker service logs` and reported by swarm only as `Starting`. The installer now refuses
+up front and offers `sh -s update` or `DOKPLOY_RESET_DB=true`.
+
+The second one also needed a second fix: removing the services is not enough, because
+their *stopped* containers keep the volume referenced and `docker volume rm` reports
+"volume is in use" for a container that is not running.
+
+### Not a bug: triplicated deploy log lines
+
+Worth recording because it looked like one. Deploy output repeated every Docker progress
+line three times. The compose file had three services sharing one image, and
+`docker compose pull` reports progress per service — `mariadb` and `redis` appeared once
+each, the shared image three times. Docker's own output, not a stream being subscribed
+to more than once.
+
 ### Docker image sizes
 
 Same machine, pre-migration commit vs now.


### PR DESCRIPTION
The README said *"No production evidence. No instance has run under sustained real load."* The first half is no longer true.

## What was verified

An instance running on **Debian 13 arm64 (Proxmox LXC)**, installed with `install.sh`, pulling the published multi-arch image from GHCR **anonymously**, deploying and serving real containers.

All six WebSocket servers exercised by hand:

| Endpoint | Mechanism | |
|---|---|---|
| `docker-container-terminal` | **Bun.Terminal** | ✅ |
| `docker-container-logs` | **Bun.Terminal** | ✅ |
| `terminal` | ssh2 | ✅ |
| `listen-deployment` | ssh2 | ✅ |
| `docker-stats` | dockerode | ✅ |
| `drawer-logs` | — | ✅ |

Plus registration (exercising `Bun.password` **and** `Bun.sql` on the write path), the migration chain applying on first boot, and a three-image Compose stack deployed end to end.

## The terminal

`node-pty` under Bun dies ~8ms after spawn and throws `EBADF` on `resize()`. The `Bun.Terminal` replacement holds a session, runs commands, and resize reaches the PTY — confirmed by `stty size` inside the container while narrowing the browser:

```
18 127  →  18 71  →  18 38
```

Rows stay fixed because `docker-terminal.tsx:122` pins the panel at `h-[420px]` — UI layout, not a runtime failure. The changing column count is what proves the mechanism.

## What is deliberately *not* claimed

The second half of the original sentence stands and is kept, reworded rather than deleted:

> **No sustained-load evidence.** The instance works; it has not been run under production traffic for a meaningful period, and nothing here is a stability claim.

Still no latency, throughput or memory numbers either.

## Also recorded

**Two installer traps**, both upstream behaviour rather than migration fallout, both now handled:

- version detection falls back to `latest`, which this fork does not publish → `No such image`
- a full install regenerates the Postgres password but the volume survives → `28P01`, invisible in `docker service logs`, reported by swarm only as `Starting`

**One thing that looked like a bug and was not:** deploy logs repeating each line three times. The compose file had three services sharing one image, and `docker compose pull` reports progress per service — `mariadb` and `redis` appeared once each, the shared image three times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)