### PR TITLE
feat: unlock every enterprise feature, with the server-access backfill it needs

### DIFF
--- a/apps/dokploy/__test__/permissions/check-permission.test.ts
+++ b/apps/dokploy/__test__/permissions/check-permission.test.ts
@@ -44,7 +44,7 @@ vi.mock("@dokploy/server/db", () => ({
 }));
 
 vi.mock("@dokploy/server/services/proprietary/license-key", () => ({
-	hasValidLicense: vi.fn(() => Promise.resolve(false)),
+	hasValidLicense: vi.fn(() => Promise.resolve(true)),
 }));
 
 const { checkPermission } = await import("@dokploy/server/services/permission");

--- a/apps/dokploy/__test__/permissions/resolve-permissions.test.ts
+++ b/apps/dokploy/__test__/permissions/resolve-permissions.test.ts
@@ -44,7 +44,7 @@ vi.mock("@dokploy/server/db", () => ({
 }));
 
 vi.mock("@dokploy/server/services/proprietary/license-key", () => ({
-	hasValidLicense: vi.fn(() => Promise.resolve(false)),
+	hasValidLicense: vi.fn(() => Promise.resolve(true)),
 }));
 
 const { resolvePermissions } = await import(

--- a/apps/dokploy/__test__/permissions/service-access.test.ts
+++ b/apps/dokploy/__test__/permissions/service-access.test.ts
@@ -45,7 +45,7 @@ vi.mock("@dokploy/server/db", () => ({
 }));
 
 vi.mock("@dokploy/server/services/proprietary/license-key", () => ({
-	hasValidLicense: vi.fn(() => Promise.resolve(false)),
+	hasValidLicense: vi.fn(() => Promise.resolve(true)),
 }));
 
 const { checkServicePermissionAndAccess, checkServiceAccess } = await import(

--- a/apps/dokploy/drizzle/0186_backfill_accessed_servers.sql
+++ b/apps/dokploy/drizzle/0186_backfill_accessed_servers.sql
@@ -1,0 +1,26 @@
+-- Data migration, hand-written on purpose: drizzle-kit generates schema diffs and
+-- cannot produce a backfill. No schema change here.
+--
+-- Enterprise licensing is being removed, which turns per-member server scoping ON
+-- for everyone. getAccessibleServerIds previously branched on the licence:
+--
+--   unlicensed -> every server in the organization   (the permissive branch)
+--   licensed   -> only member."accessedServers"      (the restrictive branch)
+--
+-- An instance that ran unlicensed never populated accessedServers, so unlocking the
+-- feature without this backfill would drop every non-admin member to zero visible
+-- servers. Seeding the column with the servers they can already see preserves
+-- today's effective access exactly, and lets admins restrict from there.
+--
+-- Only rows that are still empty are touched, so a deliberate restriction that an
+-- admin has already configured is never overwritten.
+UPDATE "member" m
+SET "accessedServers" = COALESCE(
+        (
+            SELECT array_agg(s."serverId")
+            FROM "server" s
+            WHERE s."organizationId" = m."organization_id"
+        ),
+        ARRAY[]::text[]
+    )
+WHERE cardinality(m."accessedServers") = 0;

--- a/apps/dokploy/drizzle/meta/_journal.json
+++ b/apps/dokploy/drizzle/meta/_journal.json
@@ -1303,6 +1303,13 @@
       "when": 1786526512677,
       "tag": "0185_needy_kingpin",
       "breakpoints": true
+    },
+    {
+      "idx": 186,
+      "version": "7",
+      "when": 1787017916547,
+      "tag": "0186_backfill_accessed_servers",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/services/proprietary/license-key.ts
+++ b/packages/server/src/services/proprietary/license-key.ts
@@ -7,25 +7,20 @@ import {
 import { and, eq } from "drizzle-orm";
 import { getOrganizationOwnerId } from "./sso";
 
-export const hasValidLicense = async (organizationId: string) => {
-	const ownerId = await getOrganizationOwnerId(organizationId);
-
-	if (!ownerId) {
-		return false;
-	}
-
-	const currentUser = await db.query.user.findFirst({
-		where: eq(user.id, ownerId),
-		columns: {
-			enableEnterpriseFeatures: true,
-			isValidEnterpriseLicense: true,
-		},
-	});
-	return !!(
-		currentUser?.enableEnterpriseFeatures &&
-		currentUser?.isValidEnterpriseLicense
-	);
-};
+/**
+ * Enterprise licensing is removed in this fork: every feature is available.
+ *
+ * Kept as a function returning true, rather than deleted outright, so this change
+ * is one line to revert while the behaviour is being verified. The call sites and
+ * the dead branches behind them come out separately - see
+ * .claude/skills/remove-enterprise-license/SKILL.md.
+ *
+ * Note this is not purely a feature flag. Three callers use it to choose between
+ * different access-control behaviours, and in getAccessibleServerIds the
+ * unlicensed branch was the *permissive* one - hence migration 0186, which seeds
+ * member."accessedServers" so nobody loses server visibility.
+ */
+export const hasValidLicense = async (_organizationId: string) => true;
 
 export const resolveOrganizationDefaultRole = async (
 	organizationId: string,


### PR DESCRIPTION
Steps 1–2 of the de-licensing procedure. `hasValidLicense` now returns `true` unconditionally; call sites and the dead branches behind them come out separately, so **this half is one line to revert** while behaviour is verified.

## This is not a feature-flag flip

Three callers use the licence to choose between *different access-control behaviours*, and in `getAccessibleServerIds` the **unlicensed branch is the permissive one**:

```ts
unlicensed -> every server in the organization
licensed   -> only member."accessedServers"
```

An instance that ran unlicensed never populated `accessedServers`. Unlocking the feature alone would have dropped **every non-admin member to zero visible servers**.

## Migration 0186

Seeds `accessedServers` with the servers each member can already see — preserving today's effective access exactly, and letting admins restrict from there.

Hand-written on purpose: drizzle-kit generates schema diffs and cannot produce a backfill. It touches **only rows that are still empty**, so a restriction an admin already configured is never overwritten.

### Verified against a real PostgreSQL, with fixtures

| Member | Before | After | |
|---|---|---|---|
| empty list, org A (2 servers) | `{}` | `{srv_a1, srv_a2}` | gains its own org's servers |
| empty list, org B (1 server) | `{}` | `{srv_b1}` | **no cross-org leak** |
| deliberate restriction, org A | `{srv_a1}` | `{srv_a1}` | **left untouched** |

Running it twice changed nothing. The full 187-migration chain applies clean from empty.

## The other two callers

- **`resolveRole`** now resolves custom roles instead of returning `null`, so **any row in `organizationRole` becomes live** — worth auditing that table before deploying.
- **`getAccessibleGitProviderIds`** only widens access, adding assigned providers on top of owned and shared.

## A finding worth recording

Three permission test files mocked `hasValidLicense` to `false` — asserting a branch production no longer has. **The suite stayed green through a fundamental behaviour change.**

They now mock `true` to match production. They pass either way, which means **the permission suite does not cover this branching at all**, in either direction. Worth knowing before trusting it on the next step.

The git-provider tests *do* exercise both branches deliberately (`false` and `true` per test) and are left alone until the branches themselves are removed.

## Next

Step 4 — delete `enterpriseProcedure`'s licence check, the 14 dead branches, the licence router/UI/cron, and the calls to `licenses-api.dokploy.com`. Step 5 — drop the two DB columns, one release later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)