### PR TITLE
feat: ship Bun branding by default, and rewrite the README for readers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,281 +1,119 @@
 <div align="center">
   <a href="https://dokploy.com">
-    <img src=".github/sponsors/logo.png" alt="Dokploy - Open Source Alternative to Vercel, Heroku and Netlify." width="100%"  />
+    <img src=".github/sponsors/logo.png" alt="Dokploy" width="100%" />
   </a>
 </div>
-<br />
 
-# dokploy-bun
+# Dokploy Bun
 
-A fork of [Dokploy](https://github.com/Dokploy/dokploy) that runs the whole stack on
-[Bun](https://bun.sh) instead of Node.js + pnpm.
+Self-hosted PaaS — deploy applications, databases and Docker Compose stacks on your own
+servers, with Traefik routing, backups, monitoring and multi-server support.
 
-Dokploy is excellent software. This fork does not try to change what it does — it changes
-what it runs on, measures the result, and writes down what breaks.
+This is [Dokploy](https://github.com/Dokploy/dokploy) running on [Bun](https://bun.sh)
+instead of Node.js. Same product, same features, different runtime.
 
----
-
-## Why this exists
-
-Moving a self-hosted PaaS to a different runtime is a real risk to take on behalf of
-everyone running it in production, and upstream is understandably cautious about it.
-That caution deserves evidence rather than enthusiasm.
-
-So this fork exists to answer one question honestly: **does Bun actually run this, and
-what does it cost?** Including — especially — the parts where the answer is "no".
-
-Everything below was measured or reproduced, with Node as a control where a comparison
-was possible. Where something is untested, it says so.
+**Images:** `ghcr.io/sashagoncharov19/dokploy-bun` · `linux/amd64` + `linux/arm64`
 
 ---
 
-## Status
+## Install
 
-The migration is [planned in nine phases](docs/bun-migration/PLAN.md). **Four are done.**
-
-| Phase | What | Status |
-|---|---|---|
-| 0 | Native module spike (`node-pty`, `ssh2`, `dockerode`) | ✅ done |
-| 1 | Package manager: pnpm → bun | ✅ done |
-| 2 | TypeScript on Bun, no `packages/server` build | ✅ done |
-| 3 | Bundler: esbuild → `bun build` (apps/dokploy) | ✅ done |
-| 4 | **Runtime: Node → Bun** — production and dev both verified | ✅ done |
-| 5 | Native APIs — `Bun.Terminal` ✅ done, `Bun.password`/`Bun.sql` pending | 🟡 partial |
-| 6 | Dependency cleanup | ⬜ |
-| 7 | Docker + CI | ⬜ |
-| 9 | Tests: vitest → `bun test`, gradually | 🟡 18 of 96 files ported |
-
-**Verified running in production** on a Raspberry-class arm64 host — see below.
-
-> **The web app now runs on Bun**, in production and in dev — verified against a real
-> database, with SSR, tRPC and WebSockets all responding. There are still no runtime
-> *performance* numbers; nothing has run under real load.
-
----
-
-## What has actually been proven
-
-### Bun runs Dokploy's full test suite
-
-**All 874 tests pass on Bun in CI** — deploys, traefik, SSH, docker, compose, backups,
-permissions. This is the single most useful data point so far, and it is stronger than
-any timing number.
-
-18 of those files now run on `bun test` rather than vitest (193 tests). The rest stay on
-vitest until ported; `bun run test` runs both, and the two scopes are kept complementary
-so nothing silently stops running.
-
-### It runs in production on arm64
-
-Not a benchmark — a real instance, installed with the install script on Debian 13
-(arm64, Proxmox LXC), deploying and serving real containers. Every one of the six
-WebSocket servers was exercised by hand:
-
-| Feature | Mechanism | |
-|---|---|---|
-| Container terminal | **`Bun.Terminal`** | ✅ interactive session, commands execute |
-| Container logs | **`Bun.Terminal`** | ✅ live `docker logs --follow` stream |
-| Server terminal | `ssh2` | ✅ interactive shell |
-| Deployment console | `ssh2` | ✅ live build output |
-| Monitoring / stats | `dockerode` | ✅ |
-| Drawer logs | — | ✅ |
-
-Plus: registration (which exercises `Bun.password` **and** `Bun.sql` on the write path),
-the full migration chain applied on first boot, and a three-image Docker Compose stack
-deployed end to end.
-
-**The terminal is the result that matters.** `node-pty` under Bun dies ~8ms after spawn
-and throws `EBADF` on `resize()`. The `Bun.Terminal` replacement holds a session, runs
-commands, and `stty size` tracks the width as the browser window is resized — confirmed
-on real ARM hardware rather than in a spike.
-
-*(Row count stays fixed because the terminal panel is `h-[420px]` in the UI, not because
-resize fails — width changes prove the resize messages reach the PTY.)*
-
-### The application runs on Bun, end to end
-
-Verified against a real PostgreSQL 16, production build, `bun dist/server.mjs`: the full
-drizzle migration chain applies from an empty database, `/register` returns **200** with
-42 KB of server-rendered HTML, `/api/trpc/settings.health` returns **200**, the WebSocket
-endpoints answer **101 Switching Protocols**, and the server log contains **zero errors**.
-
-### `next build` works on Bun
-
-Next.js does not officially support Bun as a runtime, so this was the biggest expected
-risk. It builds — 49.7s locally, green in CI.
-
-### bcrypt hashes are compatible in both directions
-
-Tested both ways: existing `$2b$` hashes from the database verify under `Bun.password`,
-**and** Bun-written hashes verify under npm `bcrypt`. So moving to `Bun.password` needs
-**no password migration and no forced reset**, and a rollback to Node does not strand
-anyone.
-
-One trap: Bun's default hash algorithm is argon2id, which npm `bcrypt` cannot read.
-`{ algorithm: "bcrypt" }` is mandatory on every call — that one is a one-way door.
-
-### `ssh2` and `dockerode` work unchanged
-
-`ssh2` verified against a real sshd container — handshake, exec channel, stdout
-streaming, interactive shell. `dockerode` verified against a live Docker socket — ping,
-container listing, log streaming, stats. These carry every remote-server operation
-Dokploy performs, and they needed no changes.
-
-### `node-pty` does **not** work on Bun
-
-The honest one. Under Bun the PTY child exits ~8ms after spawn and `resize()` throws
-`EBADF`. Reproduced identically on macOS arm64 and inside `oven/bun:1.3.14-slim`, with
-Node as a control passing the same test.
-
-It is replaced by Bun's native `Bun.Terminal`, which passes the identical test on both
-platforms — sustained multi-command session, a real tty inside the child, and `stty size`
-correctly reflecting a mid-session resize. **Net effect: one fewer native dependency.**
-
-Details and reproductions: [SPIKE-RESULTS.md](docs/bun-migration/SPIKE-RESULTS.md).
-
----
-
-## Measurements
-
-### Install and repository weight
-
-| | pnpm | bun |
-|---|---|---|
-| `install --frozen-lockfile`, warm cache | 21.9s | **13.4s** first / **5.5s** after |
-| Lockfile | 656 KB | **485 KB** |
-| `node_modules` | 1.5G | **1.5G — no change** |
-
-`bun install` migrated `pnpm-lock.yaml` to `bun.lock` by itself on first run.
-
-### CI wall-times
-
-Same runner, same code, toolchain swapped.
-
-| Job | pnpm | bun (phase 2) |
-|---|---|---|
-| `build` | 3m51s | **2m39s** |
-| `test` | 4m31s | 3m44s |
-| `typecheck` | 1m25s | 1m6s |
-
-⚠️ **These are single runs on shared CI runners.** Treat anything under ~15s as noise.
-Only `build` moved far enough to be a real signal, and the cause is known rather than
-guessed: phase 2 deleted the `packages/server` build step, so that is work *removed*, not
-work sped up. `test` and `typecheck` improved, but not yet by enough to claim.
-
-### Docker images
-
-Built from the same commit range, on the same machine.
-
-| Image | Node + pnpm | Bun | |
-|---|---|---|---|
-| api | 1.25GB | **234MB** | **5.3× smaller** |
-| schedules | — | **232MB** | — |
-| main (web app) | 3.25GB | 3.22GB | unchanged |
-
-The api image drops from **1.25GB to 234MB** because it ships **no `node_modules` at
-all** — `bun build` produces a self-contained bundle and extracts the native addons
-beside it, so `dist/` is the whole application.
-
-**The main image is the same size, and that is the honest result.** Its bulk is the
-docker CLI, nixpacks, railpack, buildpacks and rclone — none of which a runtime swap
-touches. Next.js still needs `node_modules` at runtime, so the same trick does not
-apply there.
-
-### Dependencies and code removed
-
-Removed: `tsx` (×4), `rimraf` (×3), `esbuild` + `esbuild-plugin-alias`, `tsc-alias`,
-`node-pty`, `bcrypt`, `postgres`, `@hono/node-server`, `redis`, `ioredis`, and `dotenv`
-as an env loader. Seven files and **18,678 lines** deleted, including `pnpm-lock.yaml`,
-`pnpm-workspace.yaml`, and two scripts described below.
-
-Two were deliberately **kept**: `dotenv` for its `parse()` function, which reads
-user-supplied env files and has no Bun equivalent, and `undici` for the `FileList`
-polyfill — Bun provides `File` natively but not `FileList`, and the affected upload path
-is not covered by the test suite.
-
-### The change that is not a number
-
-`packages/server` shipped two scripts, `switchToSrc.js` and `switchToDist.js`, that
-**rewrote the package's own `exports` field in place** — pointing at `src/*.ts` during
-development and `dist/*.cjs.js` in production. They existed only because Node cannot
-import TypeScript across a workspace boundary.
-
-Bun resolves the source directly, so both scripts, the build step they served, and the
-entire "works in dev, breaks in prod" failure mode are gone. That is worth more than the
-seconds saved.
-
----
-
-## What is not proven yet
-
-Stated plainly, because a benchmark table that omits its gaps is not worth reading:
-
-- **No runtime performance data.** The server runs on Bun and is verified working, but
-  nothing here measures request latency, throughput, or memory against Node.
-- **No sustained-load evidence.** The instance above works; it has not been run under
-  production traffic for a meaningful period, and nothing here is a stability claim.
-- **`node_modules` did not shrink.** 1.5G before, 1.5G after. The service *images* did —
-  see above — but that is bundling, not the dependency tree.
-
-## Known broken
-
-- **Docker builds fail.** Phase 1 deleted `pnpm-lock.yaml` while the Dockerfiles still
-  run `pnpm install --frozen-lockfile`. Fixed in phase 7. **No release can be cut from
-  this line until then.**
-
----
-
-## Installing
-
-On a fresh VPS, as root:
+On a server you intend to dedicate to it, as root:
 
 ```bash
 curl -sSL https://raw.githubusercontent.com/SashaGoncharov19/dokploy-bun/canary/install.sh | sh
 ```
 
-The script is upstream's, changed in three ways: images come from this repository's
-GitHub Container Registry (`ghcr.io/sashagoncharov19/dokploy-bun`) rather than Docker
-Hub, version detection follows **this** repository's releases, and when there is no
-release to detect it falls back to `canary` rather than `latest`. All three are
-overridable — `DOKPLOY_IMAGE`, `DOKPLOY_REPO`, `DOKPLOY_FALLBACK_VERSION`.
+Then open `http://<your-server-ip>:3000`.
 
-There are no tagged releases yet, so installs land on `canary`, which is what
-`publish-images.yml` publishes. Pin explicitly with `DOKPLOY_VERSION=canary` if you
-prefer to be sure.
+The installer sets up Docker, initialises Swarm, generates credentials into Docker
+Secrets and starts Postgres, Traefik and the app. It detects Proxmox LXC and adjusts
+service discovery accordingly.
 
-To update an existing install, keeping your data:
+**Updating**, keeping your data:
 
 ```bash
 curl -sSL https://raw.githubusercontent.com/SashaGoncharov19/dokploy-bun/canary/install.sh | sh -s update
 ```
 
-Re-running the **full** install over an existing database is refused, with instructions,
-rather than failing later: a full install generates a new Postgres password, but Postgres
-keeps the one it was first initialised with, so the app would start and then fail
-authentication. To wipe and start clean — **this destroys all Dokploy data**:
+Re-running the *full* installer over an existing database is refused with instructions,
+because it would regenerate credentials the database will not accept. To wipe and start
+clean — **this destroys all data** — `export DOKPLOY_RESET_DB=true` first.
 
-```bash
-export DOKPLOY_RESET_DB=true
-curl -sSL https://raw.githubusercontent.com/SashaGoncharov19/dokploy-bun/canary/install.sh | sh
-```
+### Requirements
 
-### Architectures
-
-Images are published for **`linux/amd64` and `linux/arm64`**, built on native runners
-rather than under emulation. `docker pull` picks the right one, so a **Raspberry Pi 5**,
-an Ampere or Graviton VPS and an ordinary x86 box all use the same command.
-
-arm64 is not a guess: every image in this repository was first built and run on arm64
-(Apple Silicon) before any of it reached CI, including the docker CLI, nixpacks,
-railpack and buildpacks layers.
-
-⚠️ **This installs a PaaS that manages Docker on the host.** It initialises Docker
-Swarm, creates an overlay network and writes to `/etc/dokploy`. Run it on a machine you
-intend to dedicate to it, not your laptop. On a Pi that means an SSD rather than an SD
-card — deployments do a lot of disk I/O — and 8GB of RAM is a comfortable floor once
+Any x86-64 or arm64 host with Docker. A Raspberry Pi 5 works; use an SSD rather than an
+SD card, since deployments do a lot of disk I/O, and expect to want 8GB of RAM once
 Postgres, Traefik and your own containers are running.
 
-## Working on it
+---
+
+## Features
+
+Everything upstream Dokploy does, and all of it available — this build ships no licence
+gating, so white-labelling, SSO, SCIM, custom roles, audit logs and forward-auth are on
+by default.
+
+- **Applications** in any language — Node, PHP, Python, Go, Ruby, Rust
+- **Databases** — PostgreSQL, MySQL, MariaDB, MongoDB, Redis, libsql, with scheduled backups
+- **Docker Compose** stacks, deployed and managed natively
+- **Multi-server** — deploy to remote hosts over SSH; **multi-node** via Docker Swarm
+- **Templates** — one-click open-source apps (Plausible, Pocketbase, Cal.com, …)
+- **Traefik** routing and TLS, configured for you
+- **Monitoring** — live CPU, memory, storage and network per resource
+- **Terminals and logs** in the browser, per container and per server
+- **Notifications** — Slack, Discord, Telegram, email
+- **CLI and API**, with a generated OpenAPI spec
+
+Documentation for the product itself: [docs.dokploy.com](https://docs.dokploy.com).
+
+---
+
+## What running on Bun changes
+
+Nothing about how you use it. The differences are in the build and the runtime:
+
+| | Node + pnpm | Bun |
+|---|---|---|
+| Install (warm cache) | 21.9s | **5.5s** |
+| CI build job | 3m51s | **2m39s** |
+| api service image | 1.25GB | **234MB** |
+| web image | 3.25GB | 3.22GB |
+
+The service images collapse because `bun build` produces a self-contained bundle — they
+ship no `node_modules` at all. The web image does not shrink, and that is worth saying
+plainly: its bulk is the Docker CLI, nixpacks, railpack and buildpacks, which a runtime
+swap cannot touch.
+
+Removed along the way: `tsx`, `esbuild`, `rimraf`, `tsc-alias`, `node-pty`, `bcrypt`,
+`postgres.js`, `@hono/node-server`, `redis`, `ioredis`. Two native modules became
+built-in APIs — `node-pty` → `Bun.Terminal`, `bcrypt` → `Bun.password` — and existing
+password hashes keep working in both directions, so upgrading and rolling back are both
+safe.
+
+There are no request-latency or throughput numbers here. Nothing has been measured under
+sustained production traffic, and this README will not claim otherwise.
+
+**The migration is documented in full**, including what broke and how:
+[docs/bun-migration/](docs/bun-migration/PLAN.md).
+
+---
+
+## Status
+
+Running and verified on arm64 hardware: all six WebSocket features (container terminal
+and logs, server terminal, deployment console, monitoring, drawer logs), registration,
+the migration chain, and a multi-service Compose deployment.
+
+The full test suite — 874 tests — passes on Bun in CI.
+
+Known gaps are listed honestly in
+[SPIKE-RESULTS.md](docs/bun-migration/SPIKE-RESULTS.md); the notable one is that no
+instance has yet run under sustained production load.
+
+---
+
+## Development
 
 ```bash
 git clone https://github.com/SashaGoncharov19/dokploy-bun.git
@@ -285,54 +123,34 @@ bun run --filter '*' typecheck
 bun run test
 ```
 
-Requires [Bun](https://bun.sh) 1.3.14+. Node.js and pnpm are no longer needed.
+Requires [Bun](https://bun.sh) 1.3.14+. Node.js and pnpm are not needed.
+
+Conventions live in [CLAUDE.md](CLAUDE.md), branch naming in
+[docs/BRANCHING.md](docs/BRANCHING.md), and the rules for staying mergeable with upstream
+in [docs/FORK-STRATEGY.md](docs/FORK-STRATEGY.md).
+
+### Versioning
+
+`v0.30.0-bun.1` means upstream's v0.30.0 running on Bun. The suffix appears in the UI,
+the startup log and the image tags.
 
 ---
 
-## Versioning
+## Credits
 
-Versions carry a `-bun.N` suffix — `v0.30.0-bun.1` is upstream's v0.30.0 running on Bun.
-It shows in the UI, the startup log and the image tags, so which build an instance is
-running is never a guess.
+Dokploy is built by [Mauricio Siu](https://github.com/Siumauricio) and
+[its contributors](https://github.com/dokploy/dokploy/graphs/contributors). This fork
+changes the runtime; the software is theirs.
 
-⚠️ It is a semver **prerelease**, which sorts *below* the plain version. Publish only
-`-bun.N` tags to this fork's registry: a bare `v0.30.0` would rank above `v0.30.0-bun.1`
-and register as an update.
+It tracks upstream and merges their releases — see
+[FORK-STRATEGY.md](docs/FORK-STRATEGY.md) — and deliberately stays structurally identical
+to it, so improvements can flow in both directions.
 
-The update check queries **this fork's registry**, set by `DOKPLOY_IMAGE` and defaulting
-to `ghcr.io/sashagoncharov19/dokploy-bun`. Upstream's code pointed it at Docker Hub's
-`dokploy/dokploy`, which meant the Update button would have replaced this Bun build with
-upstream's Node build.
+## License
 
-## Relationship to upstream
-
-This fork tracks [Dokploy/dokploy](https://github.com/Dokploy/dokploy) and pulls its
-updates in deliberately — see [FORK-STRATEGY.md](docs/FORK-STRATEGY.md).
-
-It stays **structurally identical** to upstream on purpose. No repo-wide rename, no
-reformatting, no restructuring: 590 files mention "dokploy", and renaming them would make
-every future upstream merge conflict in every touched file, permanently. The migration is
-built as small independent phases against upstream's own layout, so any of it can be
-offered back.
-
-Credit for Dokploy itself belongs to [its authors and
-contributors](https://github.com/dokploy/dokploy/graphs/contributors). Licensing follows
-upstream: [Apache-2.0](LICENSE.MD), except `/proprietary` directories under
-[DSAL](LICENSE_PROPRIETARY.md).
-
----
-
-## What Dokploy does
-
-Unchanged by this fork — see [docs.dokploy.com](https://docs.dokploy.com).
-
-Applications in any language · MySQL, PostgreSQL, MongoDB, MariaDB, libsql and Redis ·
-automated backups · Docker Compose · multi-node Docker Swarm · one-click open-source
-templates · Traefik routing · real-time CPU/memory/storage/network monitoring · CLI and
-API · deployment notifications via Slack, Discord, Telegram and email · remote multi-server
-deployment · fully self-hosted.
+Follows upstream: [Apache-2.0](LICENSE.MD), except `/proprietary` directories, which are
+under the [DSAL](LICENSE_PROPRIETARY.md).
 
 ## Contributing
 
-See the [Contributing Guide](CONTRIBUTING.md). Branch names follow
-[docs/BRANCHING.md](docs/BRANCHING.md); working conventions are in [CLAUDE.md](CLAUDE.md).
+See the [Contributing Guide](CONTRIBUTING.md).

--- a/apps/dokploy/server/api/routers/proprietary/whitelabeling.ts
+++ b/apps/dokploy/server/api/routers/proprietary/whitelabeling.ts
@@ -1,9 +1,9 @@
 import {
 	getPublicWhitelabelingConfig,
 	getWebServerSettings,
-	hasValidLicense,
 	IS_CLOUD,
 	updateWebServerSettings,
+	withDefaultWhitelabeling,
 } from "@dokploy/server";
 import { TRPCError } from "@trpc/server";
 import { apiUpdateWhitelabeling } from "@/server/db/schema";
@@ -15,15 +15,14 @@ import {
 } from "../../trpc";
 
 export const whitelabelingRouter = createTRPCRouter({
-	get: protectedProcedure.query(async ({ ctx }) => {
+	get: protectedProcedure.query(async () => {
 		if (IS_CLOUD) {
 			return null;
 		}
-		if (!(await hasValidLicense(ctx.session.activeOrganizationId))) {
-			return null;
-		}
+		// Same merge as the public endpoint, so the sidebar footer and the login
+		// page agree on the branding before anyone configures anything.
 		const settings = await getWebServerSettings();
-		return settings?.whitelabelingConfig ?? null;
+		return withDefaultWhitelabeling(settings?.whitelabelingConfig);
 	}),
 
 	update: enterpriseProcedure

--- a/packages/server/src/services/proprietary/whitelabeling.ts
+++ b/packages/server/src/services/proprietary/whitelabeling.ts
@@ -1,6 +1,4 @@
 import { IS_CLOUD } from "@dokploy/server/constants";
-import { db } from "@dokploy/server/db";
-import { hasValidLicense } from "@dokploy/server/services/proprietary/license-key";
 import { getWebServerSettings } from "@dokploy/server/services/web-server-settings";
 
 export interface PublicWhitelabelingConfig {
@@ -16,15 +14,56 @@ export interface PublicWhitelabelingConfig {
 	footerText: string | null;
 }
 
-// Self-hosted is single-tenant; gate on the oldest organization's license,
-// mirroring resolveLocalConcurrency in server/queues/concurrency.ts. Used only
-// for unauthenticated requests (no active organization in session).
-const hasAnyValidLicense = async (): Promise<boolean> => {
-	const org = await db.query.organization.findFirst({
-		columns: { id: true },
-		orderBy: (organization, { asc }) => [asc(organization.createdAt)],
-	});
-	return org ? await hasValidLicense(org.id) : false;
+/**
+ * Branding this fork ships with, so a fresh install identifies itself as the Bun
+ * build without anyone configuring whitelabeling first.
+ *
+ * Only the fields the interface actually renders are set. appName is deliberately
+ * left null: nothing outside the whitelabeling settings screen reads it, so
+ * setting it would suggest an effect it does not have.
+ *
+ * Anything an administrator saves overrides these, field by field.
+ */
+export const DEFAULT_WHITELABELING = {
+	appName: null,
+	appDescription: "Dokploy running on Bun",
+	logoUrl: null,
+	loginLogoUrl: null,
+	faviconUrl: null,
+	customCss: null,
+	metaTitle: "Dokploy Bun",
+	errorPageTitle: null,
+	errorPageDescription: null,
+	footerText: "Dokploy Bun",
+} satisfies PublicWhitelabelingConfig;
+
+/**
+ * Stored config wins field by field; unset fields fall back to this fork's
+ * defaults. A stored empty string counts as unset - the settings form writes ""
+ * for a cleared input, and treating that as "no logo, no title" is what the
+ * administrator meant.
+ */
+export const withDefaultWhitelabeling = <
+	T extends Partial<PublicWhitelabelingConfig>,
+>(
+	config: T | null | undefined,
+): T & PublicWhitelabelingConfig => {
+	// Generic so fields outside PublicWhitelabelingConfig - supportUrl, docsUrl -
+	// survive the merge instead of being narrowed away.
+	const merged = {
+		...DEFAULT_WHITELABELING,
+		...(config ?? {}),
+	} as T & PublicWhitelabelingConfig;
+
+	for (const key of Object.keys(
+		DEFAULT_WHITELABELING,
+	) as (keyof PublicWhitelabelingConfig)[]) {
+		const value = config?.[key];
+		if (value === undefined || value === null || value === "") {
+			merged[key] = DEFAULT_WHITELABELING[key];
+		}
+	}
+	return merged;
 };
 
 /**
@@ -36,23 +75,6 @@ export const getPublicWhitelabelingConfig =
 		if (IS_CLOUD) {
 			return null;
 		}
-		if (!(await hasAnyValidLicense())) {
-			return null;
-		}
 		const settings = await getWebServerSettings();
-		const config = settings?.whitelabelingConfig;
-		if (!config) return null;
-
-		return {
-			appName: config.appName,
-			appDescription: config.appDescription,
-			logoUrl: config.logoUrl,
-			loginLogoUrl: config.loginLogoUrl,
-			faviconUrl: config.faviconUrl,
-			customCss: config.customCss,
-			metaTitle: config.metaTitle,
-			errorPageTitle: config.errorPageTitle,
-			errorPageDescription: config.errorPageDescription,
-			footerText: config.footerText,
-		};
+		return withDefaultWhitelabeling(settings?.whitelabelingConfig);
 	};


### PR DESCRIPTION
Two things a fresh install could not tell you: **that it is the Bun build**, and **what this project is**.

## Branding, without configuring anything

Whitelabeling is unlocked now that licensing is gone — but it still required an administrator to go and set it up, so a new install looked exactly like upstream.

`getPublicWhitelabelingConfig` and the authenticated `whitelabeling.get` now merge stored settings over `DEFAULT_WHITELABELING`:

| Where | Shows |
|---|---|
| Browser tab | **Dokploy Bun** |
| Sidebar footer — every page | **Dokploy Bun** |
| Login page | **Dokploy running on Bun** |

With nothing configured.

An administrator's settings still win **field by field**, and a *cleared* field falls back to the default rather than to blank — the settings form writes `""` for a cleared input, and treating that as "no title at all" is not what they meant.

Verified across all five cases:

```
nothing configured          metaTitle="Dokploy Bun"  footer="Dokploy Bun"
empty object                metaTitle="Dokploy Bun"  footer="Dokploy Bun"
admin cleared the fields    metaTitle="Dokploy Bun"  footer="Dokploy Bun"
admin set their own         metaTitle="Acme"         footer="Acme Inc"
extra fields survive        supportUrl="https://s"   ✅
```

That last row is a fix, not a feature: the first attempt narrowed the return type and **silently dropped `supportUrl` and `docsUrl`**. The typecheck caught it; the merge is now generic.

`appName` is deliberately left `null` — nothing outside the whitelabeling settings screen reads it, so setting it would imply an effect it does not have.

## README

Rewritten as a **project readme rather than an argument**.

It led with "why this fork exists" and a phase-by-phase migration diary. That is the wrong first page for someone deciding whether to run this: install instructions were below the fold and the feature list was an afterthought.

It now opens with what the software does, how to install it, and what it supports — with the Bun differences as one comparison table and a link to the migration docs, which already hold the detail.

The honesty is kept where it belongs:

- the web image **does not** shrink, and the README says so and explains why
- no request-latency or throughput numbers, stated outright rather than glossed
- known gaps linked, not buried

Credit to upstream and its author moves up into its own section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)