### PR TITLE
docs: measure the running server, Bun against the Node baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ Documentation for the product itself: [docs.dokploy.com](https://docs.dokploy.co
 
 ## What running on Bun changes
 
-Nothing about how you use it. The differences are in the build and the runtime:
+Nothing about how you use it. The differences are in the build and in the running server.
+
+**Build and packaging:**
 
 | | Node + pnpm | Bun |
 |---|---|---|
@@ -79,6 +81,29 @@ Nothing about how you use it. The differences are in the build and the runtime:
 | CI build job | 3m51s | **2m39s** |
 | api service image | 1.25GB | **234MB** |
 | web image | 3.25GB | 3.22GB |
+
+**The running server**, measured head-to-head against a build of the pre-migration
+commit — same host, same PostgreSQL, byte-identical SSR output — with medians over
+repeated runs:
+
+| | Node | Bun |
+|---|---|---|
+| Shutdown (`docker stop` to exited) | 3019ms | **318ms** |
+| Cold boot, incl. 186 migrations | 4720ms | **3411ms** |
+| Warm start | 4244ms | **3345ms** |
+| Memory, idle | 753 MiB | **626 MiB** |
+| Memory, after load | 1315 MiB | **760 MiB** |
+| `/register` SSR throughput | 780 rps | 745 rps |
+| `/api/health` throughput | 8855 rps | 8681 rps |
+
+**Throughput did not improve.** Both endpoints are inside noise, and the baseline is
+nominally ahead on each. The request path is bounded by Next.js and React rendering,
+not by the JavaScript engine, so changing the engine does not move it — and this README
+is not going to pretend otherwise.
+
+What did move is startup, shutdown and memory. Shutdown by 9.5×, which is the one that
+shows up in practice: the service runs with `--update-order stop-first`, so every
+update waits for it.
 
 The service images collapse because `bun build` produces a self-contained bundle — they
 ship no `node_modules` at all. The web image does not shrink, and that is worth saying
@@ -91,8 +116,10 @@ built-in APIs — `node-pty` → `Bun.Terminal`, `bcrypt` → `Bun.password` —
 password hashes keep working in both directions, so upgrading and rolling back are both
 safe.
 
-There are no request-latency or throughput numbers here. Nothing has been measured under
-sustained production traffic, and this README will not claim otherwise.
+These are single-host benchmarks of a freshly started server, not observations of a
+production deployment under sustained real traffic. The harness is committed as
+[`scripts/runtime-benchmark.ts`](scripts/runtime-benchmark.ts) so the numbers can be
+re-run rather than believed.
 
 **The migration is documented in full**, including what broke and how:
 [docs/bun-migration/](docs/bun-migration/PLAN.md).

--- a/docs/bun-migration/SPIKE-RESULTS.md
+++ b/docs/bun-migration/SPIKE-RESULTS.md
@@ -505,3 +505,112 @@ locally under a swarm, so they are unverified rather than known-good — `docker
 init` changes the host Docker daemon globally, which is not something to do
 unilaterally on a dev machine. To close the gap: `docker swarm init && docker network
 create --driver overlay dokploy-network`, re-run, then `docker swarm leave --force`.
+
+---
+
+## Runtime — the Bun image against the Node baseline
+
+Everything above measures the toolchain: install, CI wall-time, image build. None of
+it says anything about the server once it is running, which is the question that
+decides whether the migration was worth doing. This section measures that.
+
+Harness: [`scripts/runtime-benchmark.ts`](../../scripts/runtime-benchmark.ts). It
+builds its own PostgreSQL and containers, runs every phase, and tears the whole thing
+down again, so these numbers can be re-run rather than taken on trust.
+
+**Setup.** One host (macOS arm64, Docker 29.4.0), one PostgreSQL 16 container, one
+database per image. `oha` generates load from the host, so the generator is identical
+for both. The Docker socket is deliberately *not* mounted: both images therefore fail
+`initializeNetwork()` in exactly the same way, and both still serve HTTP, because
+`server.listen()` runs before that call in `server.ts`.
+
+**What is comparable here, and what is not.** `/register` renders byte-identical
+output from both images — 32175 bytes, `__NEXT_DATA__` present — so the request path
+being measured is the same code doing the same work. What is *not* identical is the
+rest of the tree: the Node image is built from the **pre-migration commit**, because
+a Node build of today's tree no longer exists. Licence removal, the branding defaults
+and migration 0186 are in the Bun image and not the Node one. None of them touch
+these code paths, but this is a fork-against-ancestor comparison, not a pure runtime
+swap, and should not be quoted as one.
+
+### Results
+
+Medians, with the first run of each series discarded — the first start after an image
+has been idle pays host page-cache costs the later ones do not.
+
+| Metric | Node baseline | Bun | |
+|---|---|---|---|
+| Cold boot — empty DB, 186 migrations applied (n=4) | 4720ms | **3411ms** | 1.4× faster |
+| Warm start — already-migrated DB (n=10) | 4244ms (σ 718) | **3345ms** (σ 332) | 1.3× faster |
+| Shutdown — `docker stop` to exited (n=10) | 3019ms (σ 740) | **318ms** (σ 182) | **9.5× faster** |
+| Idle RSS, 60s settle | 753.0 MiB | **625.5 MiB** | 17% lower |
+| RSS after the load runs below | 1314.8 MiB | **759.7 MiB** | 42% lower |
+| `/api/health` — 30s, 50 concurrent | 8855 rps, p50 4.56ms | 8681 rps, p50 4.22ms | no difference |
+| `/register` SSR — 30s, 20 concurrent | 780 rps, p50 23.28ms | 745 rps, p50 24.64ms | no difference |
+
+Both load runs completed at 100% success.
+
+### Throughput did not move, and that is the honest headline
+
+Neither endpoint changed outside noise — 2% on `/api/health`, 4% on SSR, each from a
+single 30-second run, and in both cases the *baseline* is nominally ahead. The request
+path is bounded by Next.js and React rendering, not by the JavaScript engine
+underneath, so swapping the engine does not move it. Anyone repeating "Bun is faster"
+as a general claim about this migration should be shown these two rows first.
+
+### Shutdown is the row that pays for itself
+
+3019ms → 318ms is the largest effect measured anywhere in this migration, and it is
+not academic. `install.sh` creates the service with `--update-order stop-first`, so
+every single Dokploy update waits for this shutdown before the new task starts. The
+Node baseline also swings between 1834ms and 4156ms; the Bun build sits at 250–894ms.
+
+Faster *and* an order of magnitude more predictable, on the one path that runs during
+every upgrade.
+
+### Startup: real, but smaller than one run made it look
+
+An earlier five-repetition pass had the Node baseline *winning* warm start at 2826ms
+against 3340ms. It was wrong. Node's warm start is bimodal — it lands near 2800ms or
+near 4300ms with nothing in between — and five samples happened to catch two of the
+fast ones. Extending to eleven and dropping the warm-up reversed the result: 4244ms
+against 3345ms.
+
+Recorded because the failure mode is the point. The measurement was not noisy in a way
+that looked noisy; it was stable enough to read as a finding and still wrong. The
+standard deviations are the tell — 718ms against 332ms.
+
+### Memory is genuinely lower, but read RSS carefully
+
+Idle is 17% lower. The post-load figure is the striking one: under identical load the
+Node baseline grew ~562 MiB and did not give it back, where the Bun build grew ~134 MiB.
+
+That is memory **held**, not memory **needed**. V8 and JavaScriptCore have different
+heap-growth and collection strategies, and neither runtime was asked to collect before
+the sample was taken. It is what an operator sees in `docker stats`, which is why it
+is worth recording — but it is not evidence of a leak in either build.
+
+### Image sizes, re-measured alongside
+
+| Image | Node + pnpm | Bun | |
+|---|---|---|---|
+| main (web app) | 3.25GB, 22 layers | 3.22GB, 25 layers | unchanged |
+| api | 1.25GB, 11 layers | 234MB, 8 layers | 5.3× smaller |
+| schedules | — | 232MB, 8 layers | — |
+
+Same figures as the earlier table, in the decimal units `docker images` prints; the
+layer counts are new.
+
+Same conclusion as before: the service images collapse because `bun build` emits a
+self-contained bundle, and the main image does not, because its bulk is the docker
+CLI, nixpacks, railpack, buildpacks, rclone and git-lfs — none of which a runtime swap
+can touch.
+
+### Summary
+
+Three real wins, one large one, and one non-result:
+
+- **Shutdown 9.5× faster**, on the critical path of every update.
+- **Memory 17% lower idle, 42% lower after load.**
+- **Boot 1.3–1.4× faster**, cold and warm.
+- **Throughput unchanged.** Not a regression, not a win.

--- a/scripts/runtime-benchmark.ts
+++ b/scripts/runtime-benchmark.ts
@@ -1,0 +1,332 @@
+#!/usr/bin/env bun
+/**
+ * Head-to-head runtime benchmark: this fork's Bun image against a Node build.
+ *
+ * The numbers in docs/bun-migration/SPIKE-RESULTS.md come from this script. It
+ * exists so they can be re-run rather than taken on trust.
+ *
+ * What it does NOT measure: build tooling. Install time, CI wall-time and image
+ * size are covered separately in that document.
+ *
+ *   docker build -t dokploy-bun-main:latest .
+ *   git stash && git checkout <pre-migration-commit>
+ *   docker build -t dokploy-node-baseline:latest .
+ *   bun scripts/runtime-benchmark.ts
+ *
+ * Both images need to exist locally. Nothing is pulled and nothing is pushed.
+ * The containers are created on their own network with a `dokbench-` prefix, so
+ * this does not disturb anything else running on the host, and the Docker socket
+ * is deliberately NOT mounted: the benchmark is about HTTP and memory, and an
+ * unmounted socket keeps the host untouched. Both images fail
+ * `initializeNetwork()` identically as a result, and both still serve HTTP
+ * because `server.listen()` runs before that call in server.ts.
+ */
+
+const PG = "dokbench-pg";
+const NET = "dokbench";
+
+/** Boot repetitions. The first of each is discarded as warm-up. */
+const BOOT_REPS = 5;
+const START_REPS = 11;
+
+interface Target {
+	name: string;
+	image: string;
+	db: string;
+	port: number;
+	container: string;
+}
+
+const TARGETS: Target[] = [
+	{
+		name: "node",
+		image: "dokploy-node-baseline:latest",
+		db: "dokploy_node",
+		port: 3802,
+		container: "dokbench-node",
+	},
+	{
+		name: "bun",
+		image: "dokploy-bun-main:latest",
+		db: "dokploy_bun",
+		port: 3801,
+		container: "dokbench-bun",
+	},
+];
+
+const sh = async (cmd: string[]) => {
+	const p = Bun.spawn(cmd, { stdout: "pipe", stderr: "pipe" });
+	const out = await new Response(p.stdout).text();
+	await new Response(p.stderr).text();
+	await p.exited;
+	return out.trim();
+};
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+const median = (xs: number[]) => {
+	const s = [...xs].sort((a, b) => a - b);
+	const m = Math.floor(s.length / 2);
+	return s.length % 2 ? s[m]! : (s[m - 1]! + s[m]!) / 2;
+};
+
+/** Poll until the server answers 200. Returns ms elapsed since `t0`. */
+const waitForHealth = async (port: number, t0: number, timeoutMs = 180_000) => {
+	while (Date.now() - t0 < timeoutMs) {
+		try {
+			const res = await fetch(`http://localhost:${port}/api/health`, {
+				signal: AbortSignal.timeout(1000),
+			});
+			if (res.status === 200) {
+				await res.text();
+				return Date.now() - t0;
+			}
+		} catch {
+			// not listening yet
+		}
+		await sleep(25);
+	}
+	return Number.NaN;
+};
+
+const resetDb = (db: string) =>
+	sh([
+		"docker",
+		"exec",
+		PG,
+		"psql",
+		"-U",
+		"dokploy",
+		"-d",
+		"postgres",
+		"-c",
+		`DROP DATABASE IF EXISTS ${db} WITH (FORCE);`,
+		"-c",
+		`CREATE DATABASE ${db};`,
+	]);
+
+const createContainer = async (t: Target) => {
+	await sh(["docker", "rm", "-f", t.container]);
+	await sh([
+		"docker",
+		"create",
+		"--name",
+		t.container,
+		"--network",
+		NET,
+		"-e",
+		`DATABASE_URL=postgres://dokploy:bench@${PG}:5432/${t.db}`,
+		"-e",
+		"BETTER_AUTH_SECRET=benchsecret",
+		"-e",
+		"NODE_ENV=production",
+		"-e",
+		"PORT=3000",
+		"-p",
+		`${t.port}:3000`,
+		t.image,
+	]);
+};
+
+/** Container memory in MiB, as Docker itself reports it. */
+const rss = async (container: string) => {
+	const out = await sh([
+		"docker",
+		"stats",
+		"--no-stream",
+		"--format",
+		"{{.MemUsage}}",
+		container,
+	]);
+	const raw = out.split("/")[0]?.trim() ?? "";
+	const n = Number.parseFloat(raw);
+	if (Number.isNaN(n)) return Number.NaN;
+	if (raw.endsWith("GiB")) return n * 1024;
+	if (raw.endsWith("KiB")) return n / 1024;
+	return n;
+};
+
+const sampleRss = async (container: string, samples = 5) => {
+	const xs: number[] = [];
+	for (let i = 0; i < samples; i++) {
+		xs.push(await rss(container));
+		await sleep(2000);
+	}
+	return median(xs.filter((x) => !Number.isNaN(x)));
+};
+
+const load = async (url: string, seconds: number, concurrency: number) => {
+	const out = await sh([
+		"oha",
+		"-z",
+		`${seconds}s`,
+		"-c",
+		String(concurrency),
+		"--no-tui",
+		"--output-format",
+		"json",
+		url,
+	]);
+	const d = JSON.parse(out);
+	return {
+		rps: d.summary.requestsPerSec as number,
+		p50: (d.latencyPercentiles.p50 as number) * 1000,
+		p95: (d.latencyPercentiles.p95 as number) * 1000,
+		p99: (d.latencyPercentiles.p99 as number) * 1000,
+		successRate: d.summary.successRate as number,
+	};
+};
+
+const setupInfra = async () => {
+	await sh(["docker", "network", "create", NET]);
+	await sh(["docker", "rm", "-f", PG]);
+	await sh([
+		"docker",
+		"run",
+		"-d",
+		"--name",
+		PG,
+		"--network",
+		NET,
+		"-e",
+		"POSTGRES_USER=dokploy",
+		"-e",
+		"POSTGRES_PASSWORD=bench",
+		"-e",
+		"POSTGRES_DB=postgres",
+		"postgres:16",
+	]);
+	for (let i = 0; i < 60; i++) {
+		const out = await sh(["docker", "exec", PG, "pg_isready", "-U", "dokploy"]);
+		if (out.includes("accepting connections")) return;
+		await sleep(1000);
+	}
+	throw new Error("postgres did not become ready");
+};
+
+const teardown = async () => {
+	for (const t of TARGETS) await sh(["docker", "rm", "-f", t.container]);
+	await sh(["docker", "rm", "-f", PG]);
+	await sh(["docker", "network", "rm", NET]);
+};
+
+// ---------------------------------------------------------------------------
+
+const results: Record<string, Record<string, unknown>> = {};
+for (const t of TARGETS) results[t.name] = {};
+
+await setupInfra();
+
+try {
+	console.log("=== cold boot (fresh database, full migration chain) ===");
+	const cold: Record<string, number[]> = { node: [], bun: [] };
+	for (let rep = 0; rep < BOOT_REPS; rep++) {
+		// Alternate order so host-level drift is shared evenly between targets.
+		const order = rep % 2 === 0 ? TARGETS : [...TARGETS].reverse();
+		for (const t of order) {
+			await resetDb(t.db);
+			await createContainer(t);
+			const t0 = Date.now();
+			await sh(["docker", "start", t.container]);
+			const ms = await waitForHealth(t.port, t0);
+			cold[t.name]!.push(ms);
+			console.log(`  rep ${rep + 1} ${t.name.padEnd(4)} ${ms}ms`);
+			await sh(["docker", "stop", t.container]);
+		}
+	}
+
+	console.log("\n=== start and stop (already-migrated database) ===");
+	const start: Record<string, number[]> = { node: [], bun: [] };
+	const stop: Record<string, number[]> = { node: [], bun: [] };
+	for (const t of TARGETS) await sh(["docker", "start", t.container]);
+	for (const t of TARGETS) await waitForHealth(t.port, Date.now());
+	for (let rep = 0; rep < START_REPS; rep++) {
+		const order = rep % 2 === 0 ? TARGETS : [...TARGETS].reverse();
+		for (const t of order) {
+			// Stop is timed separately rather than using `docker restart`, which
+			// would fold shutdown into the start number.
+			const s0 = Date.now();
+			await sh(["docker", "stop", t.container]);
+			stop[t.name]!.push(Date.now() - s0);
+
+			const t0 = Date.now();
+			await sh(["docker", "start", t.container]);
+			const ms = await waitForHealth(t.port, t0);
+			start[t.name]!.push(ms);
+			console.log(
+				`  rep ${rep + 1} ${t.name.padEnd(4)} start ${ms}ms  stop ${stop[t.name]!.at(-1)}ms`,
+			);
+			await sleep(5000);
+		}
+	}
+
+	console.log("\n=== idle memory (60s settle) ===");
+	await sleep(60_000);
+	for (const t of TARGETS) {
+		results[t.name]!.idleRss = await sampleRss(t.container);
+		console.log(
+			`  ${t.name.padEnd(4)} ${(results[t.name]!.idleRss as number).toFixed(1)} MiB`,
+		);
+	}
+
+	console.log("\n=== load ===");
+	const SCENARIOS = [
+		{ key: "health", path: "/api/health", seconds: 30, concurrency: 50 },
+		{ key: "ssr", path: "/register", seconds: 30, concurrency: 20 },
+	];
+	for (const s of SCENARIOS) {
+		const order = s.key === "health" ? TARGETS : [...TARGETS].reverse();
+		for (const t of order) {
+			const r = await load(
+				`http://localhost:${t.port}${s.path}`,
+				s.seconds,
+				s.concurrency,
+			);
+			results[t.name]![s.key] = r;
+			console.log(
+				`  ${t.name.padEnd(4)} ${s.key.padEnd(6)} ${r.rps.toFixed(0)} rps  ` +
+					`p50 ${r.p50.toFixed(2)}ms  p95 ${r.p95.toFixed(2)}ms  ` +
+					`p99 ${r.p99.toFixed(2)}ms  ok ${(r.successRate * 100).toFixed(1)}%`,
+			);
+			await sleep(10_000);
+		}
+	}
+
+	console.log("\n=== memory after load ===");
+	for (const t of TARGETS) {
+		results[t.name]!.loadedRss = await sampleRss(t.container);
+		console.log(
+			`  ${t.name.padEnd(4)} ${(results[t.name]!.loadedRss as number).toFixed(1)} MiB`,
+		);
+	}
+
+	// Drop rep 1 of each series: the first run of an image pays host page-cache
+	// costs the later ones do not, and it skews a five-sample median.
+	for (const t of TARGETS) {
+		const r = results[t.name]!;
+		r.cold = cold[t.name];
+		r.start = start[t.name];
+		r.stop = stop[t.name];
+		r.coldMedian = median(cold[t.name]!.slice(1));
+		r.startMedian = median(start[t.name]!.slice(1));
+		r.stopMedian = median(stop[t.name]!.slice(1));
+	}
+
+	console.log("\n=== medians (warm-up run excluded) ===");
+	for (const t of TARGETS) {
+		const r = results[t.name]!;
+		console.log(
+			`  ${t.name.padEnd(4)} cold ${r.coldMedian}ms  start ${r.startMedian}ms  ` +
+				`stop ${r.stopMedian}ms  idle ${(r.idleRss as number).toFixed(1)}MiB  ` +
+				`loaded ${(r.loadedRss as number).toFixed(1)}MiB`,
+		);
+	}
+
+	await Bun.write(
+		"runtime-benchmark-results.json",
+		JSON.stringify(results, null, 2),
+	);
+	console.log("\nwrote runtime-benchmark-results.json");
+} finally {
+	await teardown();
+}


### PR DESCRIPTION
Every number in this repo so far measured the **toolchain** — install time, CI wall-time, image build. Nothing measured the **server**, which is the question that actually decides whether the migration was worth doing. `SPIKE-RESULTS.md:149` said as much: *"Not yet measured: server cold-boot time and RSS."*

Adds [`scripts/runtime-benchmark.ts`](scripts/runtime-benchmark.ts), which stands up its own PostgreSQL and containers, runs boot / shutdown / memory / load phases against both images, and tears the whole thing down. Committed so the numbers can be re-run rather than believed.

## Results

Medians, first run of each series discarded as warm-up.

| Metric | Node baseline | Bun | |
|---|---|---|---|
| Shutdown (`docker stop` → exited), n=10 | 3019ms (σ 740) | **318ms** (σ 182) | **9.5× faster** |
| Cold boot, empty DB + 186 migrations, n=4 | 4720ms | **3411ms** | 1.4× |
| Warm start, migrated DB, n=10 | 4244ms (σ 718) | **3345ms** (σ 332) | 1.3× |
| Idle RSS | 753 MiB | **626 MiB** | 17% lower |
| RSS after load | 1315 MiB | **760 MiB** | 42% lower |
| `/register` SSR, 30s @ 20 | 780 rps, p50 23.28ms | 745 rps, p50 24.64ms | no change |
| `/api/health`, 30s @ 50 | 8855 rps, p50 4.56ms | 8681 rps, p50 4.22ms | no change |

## Throughput did not improve

Both endpoints are inside noise and the **baseline is nominally ahead on each**. The request path is bounded by Next.js and React rendering, not by the engine underneath, so swapping the engine does not move it. The README previously left room to imply a general speedup; it now says this outright.

## Shutdown is the one that pays for itself

`install.sh` creates the service with `--update-order stop-first`, so every Dokploy update waits for shutdown before the new task starts. Node swings 1834–4156ms, Bun sits at 250–894ms. Faster *and* an order of magnitude more predictable, on the path that runs during every upgrade.

## Two methodology corrections, recorded rather than quietly fixed

1. The first pass timed `docker restart`, which folds shutdown **into** the start number — which is why Node's "warm boot" came out slower than its own cold boot. Stop is now timed separately.
2. The second pass, at n=5, had Node **winning** warm start (2826ms vs 3340ms). That was wrong. Node's warm start is bimodal — roughly 2800ms or 4300ms, nothing between — and five samples caught two fast ones. Eleven reversed it. Worth recording because the measurement was stable enough to read as a finding and still wrong; the σ values are the tell.

## Caveats stated in the doc

- The Node image is built from the **pre-migration commit**, since a Node build of today's tree no longer exists. This is a fork-against-ancestor comparison, not a pure runtime swap. `/register` output is byte-identical between the two (32175 bytes), so the measured path is the same code — but the trees differ elsewhere.
- Post-load RSS is memory **held**, not memory **needed**. V8 and JSC collect differently and neither was asked to collect before sampling. It is what `docker stats` shows; it is not evidence of a leak.
- Single-host, freshly started server. Not production traffic.

Image sizes were re-measured and are **unchanged** — the earlier table was already correct. My first draft restated them in MiB, which made identical values look like a discrepancy; both docs now use the decimal units `docker images` prints. Layer counts are new.

Docs only plus one new script — no application code touched.