### PR TITLE
fix: let the container terminal grow taller than 420px

### DIFF
--- a/apps/dokploy/components/dashboard/docker/terminal/docker-terminal.tsx
+++ b/apps/dokploy/components/dashboard/docker/terminal/docker-terminal.tsx
@@ -119,7 +119,7 @@ export const DockerTerminal: React.FC<Props> = ({
 				</div>
 			)}
 			{hasContainer ? (
-				<div className="w-full h-[420px] rounded-lg p-2 bg-transparent border">
+				<div className="w-full h-[60vh] min-h-[420px] rounded-lg p-2 bg-transparent border">
 					<div id={id} ref={termRef} className="h-full" />
 				</div>
 			) : (


### PR DESCRIPTION
Reported symptom: resizing the container terminal changed **columns but never rows** — `stty size` returning `18 127`, `18 71`, `18 38` across three widths.

## This is not a PTY bug

The resize path is correct end to end, and the column tracking is the proof:

```
ResizeObserver → addonFit.fit() → term.onResize → ws {type:"resize"} → ptyProcess.resize(cols, rows)
```

Both `parseTerminalSize` and `parseResizeMessage` handle rows and columns symmetrically. Nothing in the `Bun.Terminal` work is involved.

## What is actually happening

The wrapper is `w-full h-[420px]`. Width is fluid; **height is nailed**. So `fit()` recomputes the same row count forever:

| | |
|---|---|
| container | 420px − 16px (`p-2`) = 404px usable |
| cell | 15px font × 1.4 lineHeight ≈ 21px |
| rows | 404 ÷ 21 ≈ **19**, invariant |

That reproduces the reported 18 within xterm's internal metrics, and explains precisely why only one axis moved.

## The change

`h-[420px]` is not ours — it came from upstream `ff275fe94`, which changed it *from* `h-full`, presumably because `h-full` collapsed inside a flex column with no defined parent height. Reverting that would risk reintroducing whatever they were fixing.

So the floor stays exactly where upstream put it and only the ceiling moves:

```diff
-<div className="w-full h-[420px] rounded-lg p-2 bg-transparent border">
+<div className="w-full h-[60vh] min-h-[420px] rounded-lg p-2 bg-transparent border">
```

Never shorter than today, taller when there is room:

| viewport | container | rows |
|---|---|---|
| 700px | 420px (floor holds) | 19 |
| 900px | 540px | 24 |
| 1080px | 648px | **30** |
| 1440px | 864px | **40** |

One class string, one file — trivially revertible, and minimal on purpose since this is an upstream file.

## Verification

Typecheck and lint pass. **Not confirmed in a browser** — the page is behind authentication and I did not have a session. The diagnosis rests on the source and on the reported `stty size` output, which the arithmetic above reproduces. Worth a quick look in the running instance after merge.