### PR TITLE
chore: remove the dead code the licence removal left behind

### DIFF
--- a/apps/dokploy/components/dashboard/settings/users/add-permissions.tsx
+++ b/apps/dokploy/components/dashboard/settings/users/add-permissions.tsx
@@ -3,7 +3,6 @@ import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
-import { EnterpriseFeatureLocked } from "@/components/proprietary/enterprise-feature-gate";
 import { AlertBlock } from "@/components/shared/alert-block";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -199,18 +198,15 @@ export const AddUserPermissions = ({ userId, role }: Props) => {
 	const { data: projects } = api.project.allForPermissions.useQuery(undefined, {
 		enabled: isOpen,
 	});
-	// Licensing is removed: every enterprise feature is available.
-	const haveValidLicense = true;
-
 	const { data: gitProviders } = api.gitProvider.allForPermissions.useQuery(
 		undefined,
 		{
-			enabled: isOpen && !!haveValidLicense,
+			enabled: isOpen,
 		},
 	);
 
 	const { data: servers } = api.server.allForPermissions.useQuery(undefined, {
-		enabled: isOpen && !!haveValidLicense,
+		enabled: isOpen,
 	});
 
 	const { data, refetch } = api.user.one.useQuery(
@@ -892,151 +888,131 @@ export const AddUserPermissions = ({ userId, role }: Props) => {
 								</FormItem>
 							)}
 						/>
-						{haveValidLicense ? (
-							<FormField
-								control={form.control}
-								name="accessedGitProviders"
-								render={() => (
-									<FormItem className="md:col-span-2">
-										<div className="mb-4">
-											<FormLabel className="text-base">Git Providers</FormLabel>
-											<FormDescription>
-												Select the Git Providers that the user can access
-											</FormDescription>
-										</div>
-										{gitProviders?.length === 0 && (
-											<p className="text-sm text-muted-foreground">
-												No git providers found
-											</p>
-										)}
-										<div className="grid md:grid-cols-1 gap-2">
-											{gitProviders?.map((provider) => (
-												<FormField
-													key={provider.gitProviderId}
-													control={form.control}
-													name="accessedGitProviders"
-													render={({ field }) => (
-														<FormItem className="flex flex-row items-center space-x-3 space-y-0 rounded-lg border p-3">
-															<FormControl>
-																<Checkbox
-																	checked={field.value?.includes(
-																		provider.gitProviderId,
-																	)}
-																	onCheckedChange={(checked) => {
-																		if (checked) {
-																			field.onChange([
-																				...(field.value || []),
-																				provider.gitProviderId,
-																			]);
-																		} else {
-																			field.onChange(
-																				field.value?.filter(
-																					(v) => v !== provider.gitProviderId,
-																				),
-																			);
-																		}
-																	}}
-																/>
-															</FormControl>
-															<div className="flex items-center gap-2">
-																<FormLabel className="text-sm cursor-pointer">
-																	{provider.name}
-																</FormLabel>
-																<span className="text-xs text-muted-foreground capitalize">
-																	({provider.providerType})
-																</span>
-															</div>
-														</FormItem>
-													)}
-												/>
-											))}
-										</div>
-										<FormMessage />
-									</FormItem>
-								)}
-							/>
-						) : (
-							<div className="md:col-span-2">
-								<EnterpriseFeatureLocked
-									compact
-									title="Git Provider Assignment"
-									description="Assign specific Git Providers to users with an Enterprise license."
-								/>
-							</div>
-						)}
-						{haveValidLicense ? (
-							<FormField
-								control={form.control}
-								name="accessedServers"
-								render={() => (
-									<FormItem className="md:col-span-2">
-										<div className="mb-4">
-											<FormLabel className="text-base">Servers</FormLabel>
-											<FormDescription>
-												Select the Servers that the user can access
-											</FormDescription>
-										</div>
-										{servers?.length === 0 && (
-											<p className="text-sm text-muted-foreground">
-												No servers found
-											</p>
-										)}
-										<div className="grid md:grid-cols-1 gap-2">
-											{servers?.map((s) => (
-												<FormField
-													key={s.serverId}
-													control={form.control}
-													name="accessedServers"
-													render={({ field }) => (
-														<FormItem className="flex flex-row items-center space-x-3 space-y-0 rounded-lg border p-3">
-															<FormControl>
-																<Checkbox
-																	checked={field.value?.includes(s.serverId)}
-																	onCheckedChange={(checked) => {
-																		if (checked) {
-																			field.onChange([
-																				...(field.value || []),
-																				s.serverId,
-																			]);
-																		} else {
-																			field.onChange(
-																				field.value?.filter(
-																					(v) => v !== s.serverId,
-																				),
-																			);
-																		}
-																	}}
-																/>
-															</FormControl>
-															<div className="flex items-center gap-2">
-																<FormLabel className="text-sm cursor-pointer">
-																	{s.name}
-																</FormLabel>
-																<span className="text-xs text-muted-foreground">
-																	({s.ipAddress})
-																</span>
-																<span className="text-xs text-muted-foreground capitalize">
-																	{s.serverType}
-																</span>
-															</div>
-														</FormItem>
-													)}
-												/>
-											))}
-										</div>
-										<FormMessage />
-									</FormItem>
-								)}
-							/>
-						) : (
-							<div className="md:col-span-2">
-								<EnterpriseFeatureLocked
-									compact
-									title="Server Assignment"
-									description="Assign specific Servers to users with an Enterprise license."
-								/>
-							</div>
-						)}
+						<FormField
+							control={form.control}
+							name="accessedGitProviders"
+							render={() => (
+								<FormItem className="md:col-span-2">
+									<div className="mb-4">
+										<FormLabel className="text-base">Git Providers</FormLabel>
+										<FormDescription>
+											Select the Git Providers that the user can access
+										</FormDescription>
+									</div>
+									{gitProviders?.length === 0 && (
+										<p className="text-sm text-muted-foreground">
+											No git providers found
+										</p>
+									)}
+									<div className="grid md:grid-cols-1 gap-2">
+										{gitProviders?.map((provider) => (
+											<FormField
+												key={provider.gitProviderId}
+												control={form.control}
+												name="accessedGitProviders"
+												render={({ field }) => (
+													<FormItem className="flex flex-row items-center space-x-3 space-y-0 rounded-lg border p-3">
+														<FormControl>
+															<Checkbox
+																checked={field.value?.includes(
+																	provider.gitProviderId,
+																)}
+																onCheckedChange={(checked) => {
+																	if (checked) {
+																		field.onChange([
+																			...(field.value || []),
+																			provider.gitProviderId,
+																		]);
+																	} else {
+																		field.onChange(
+																			field.value?.filter(
+																				(v) => v !== provider.gitProviderId,
+																			),
+																		);
+																	}
+																}}
+															/>
+														</FormControl>
+														<div className="flex items-center gap-2">
+															<FormLabel className="text-sm cursor-pointer">
+																{provider.name}
+															</FormLabel>
+															<span className="text-xs text-muted-foreground capitalize">
+																({provider.providerType})
+															</span>
+														</div>
+													</FormItem>
+												)}
+											/>
+										))}
+									</div>
+									<FormMessage />
+								</FormItem>
+							)}
+						/>
+						<FormField
+							control={form.control}
+							name="accessedServers"
+							render={() => (
+								<FormItem className="md:col-span-2">
+									<div className="mb-4">
+										<FormLabel className="text-base">Servers</FormLabel>
+										<FormDescription>
+											Select the Servers that the user can access
+										</FormDescription>
+									</div>
+									{servers?.length === 0 && (
+										<p className="text-sm text-muted-foreground">
+											No servers found
+										</p>
+									)}
+									<div className="grid md:grid-cols-1 gap-2">
+										{servers?.map((s) => (
+											<FormField
+												key={s.serverId}
+												control={form.control}
+												name="accessedServers"
+												render={({ field }) => (
+													<FormItem className="flex flex-row items-center space-x-3 space-y-0 rounded-lg border p-3">
+														<FormControl>
+															<Checkbox
+																checked={field.value?.includes(s.serverId)}
+																onCheckedChange={(checked) => {
+																	if (checked) {
+																		field.onChange([
+																			...(field.value || []),
+																			s.serverId,
+																		]);
+																	} else {
+																		field.onChange(
+																			field.value?.filter(
+																				(v) => v !== s.serverId,
+																			),
+																		);
+																	}
+																}}
+															/>
+														</FormControl>
+														<div className="flex items-center gap-2">
+															<FormLabel className="text-sm cursor-pointer">
+																{s.name}
+															</FormLabel>
+															<span className="text-xs text-muted-foreground">
+																({s.ipAddress})
+															</span>
+															<span className="text-xs text-muted-foreground capitalize">
+																{s.serverType}
+															</span>
+														</div>
+													</FormItem>
+												)}
+											/>
+										))}
+									</div>
+									<FormMessage />
+								</FormItem>
+							)}
+						/>
 						<DialogFooter className="flex w-full flex-row justify-end md:col-span-2">
 							<Button
 								isLoading={isPending}

--- a/apps/dokploy/components/layouts/side.tsx
+++ b/apps/dokploy/components/layouts/side.tsx
@@ -21,7 +21,6 @@ import {
 	Globe,
 	HardDrive,
 	House,
-	Key,
 	KeyRound,
 	LayoutGrid,
 	Loader2,
@@ -416,14 +415,6 @@ const MENU: Menu = {
 			icon: CreditCard,
 			// Only enabled for owners in cloud environments
 			isEnabled: ({ auth, isCloud }) => !!(auth?.role === "owner" && isCloud),
-		},
-		{
-			isSingle: true,
-			title: "License",
-			url: "/dashboard/settings/license",
-			icon: Key,
-			// Only enabled for owners
-			isEnabled: ({ auth }) => !!(auth?.role === "owner"),
 		},
 		{
 			isSingle: true,

--- a/apps/dokploy/components/proprietary/enterprise-feature-gate.tsx
+++ b/apps/dokploy/components/proprietary/enterprise-feature-gate.tsx
@@ -1,83 +1,14 @@
 "use client";
 
-import { Loader2, Lock } from "lucide-react";
-import Link from "next/link";
-import { Button } from "@/components/ui/button";
-import {
-	Card,
-	CardContent,
-	CardDescription,
-	CardHeader,
-	CardTitle,
-} from "@/components/ui/card";
-import { api } from "@/utils/api";
-
-interface EnterpriseFeatureLockedProps {
-	/** Optional title override */
-	title?: string;
-	/** Optional description override */
-	description?: string;
-	/** Optional custom CTA label */
-	ctaLabel?: string;
-	/** Optional CTA href (default: /dashboard/settings/license) */
-	ctaHref?: string;
-	/** Compact variant (less padding, smaller icon) */
-	compact?: boolean;
-}
-
-/**
- * Displays a locked state for enterprise features when the user has no valid license.
- * Use standalone or via EnterpriseFeatureGate.
- */
-export function EnterpriseFeatureLocked({
-	title = "Enterprise feature",
-	description = "This feature is part of Dokploy Enterprise. Add a valid license to use it.",
-	ctaLabel = "Go to License",
-	ctaHref = "/dashboard/settings/license",
-	compact = false,
-}: EnterpriseFeatureLockedProps) {
-	return (
-		<Card className="border-dashed bg-transparent">
-			<CardHeader className={compact ? "pb-2" : undefined}>
-				<div className="flex flex-col items-center gap-3 text-center">
-					<div
-						className={
-							compact
-								? "rounded-full bg-muted p-3"
-								: "rounded-full bg-muted p-4"
-						}
-					>
-						<Lock
-							className={
-								compact
-									? "size-6 text-muted-foreground"
-									: "size-8 text-muted-foreground"
-							}
-						/>
-					</div>
-					<div className="space-y-1">
-						<CardTitle className="text-lg">{title}</CardTitle>
-						<CardDescription className="max-w-sm mx-auto">
-							{description}
-						</CardDescription>
-					</div>
-				</div>
-			</CardHeader>
-			<CardContent className={compact ? "pt-0" : undefined}>
-				<div className="flex justify-center">
-					<Button asChild variant="secondary" size={compact ? "sm" : "default"}>
-						<Link href={ctaHref}>{ctaLabel}</Link>
-					</Button>
-				</div>
-			</CardContent>
-		</Card>
-	);
-}
-
 interface EnterpriseFeatureGateProps {
 	children: React.ReactNode;
 	/** Unused: kept so call sites do not have to change. */
-	lockedProps?: Omit<EnterpriseFeatureLockedProps, "compact">;
+	lockedProps?: {
+		title?: string;
+		description?: string;
+		ctaLabel?: string;
+		ctaHref?: string;
+	};
 	/** Unused: kept so call sites do not have to change. */
 	fallback?: React.ReactNode;
 }
@@ -88,8 +19,6 @@ interface EnterpriseFeatureGateProps {
  * Licensing is removed in this fork, so there is nothing to gate. The component
  * stays as a pass-through rather than being deleted, because unwrapping it would
  * mean JSX surgery across five call sites for no behavioural gain.
- * EnterpriseFeatureLocked above is still exported: add-permissions.tsx references
- * it from a branch that is now unreachable.
  */
 export function EnterpriseFeatureGate({
 	children,


### PR DESCRIPTION
Three leftovers from #21. One of them is user-visible on every instance.

## The sidebar linked to a page that no longer exists

`side.tsx` still carried a **License** nav entry pointing at `/dashboard/settings/license` — the page #21 deleted. It was gated on `auth?.role === "owner"`, so **every instance owner sees a menu item that 404s**. Removed, along with the `Key` icon import it was the only user of.

## `add-permissions.tsx` branched on a hardcoded constant

```ts
// Licensing is removed: every enterprise feature is available.
const haveValidLicense = true;
```

It fed two ternaries and two query `enabled` flags, so one half of each ternary was unreachable. Live branches inlined, dead ones deleted.

The diffstat looks alarming (278 lines) — almost all of it is re-indentation from unwrapping the JSX. Ignoring whitespace it is **2 insertions, 26 deletions**:

```
-import { EnterpriseFeatureLocked } from "@/components/proprietary/enterprise-feature-gate";
-	const haveValidLicense = true;
-			enabled: isOpen && !!haveValidLicense,
+			enabled: isOpen,
-		enabled: isOpen && !!haveValidLicense,
+		enabled: isOpen,
-						{haveValidLicense ? (
-						) : (   ...EnterpriseFeatureLocked "Git Provider Assignment"...
-						{haveValidLicense ? (
-						) : (   ...EnterpriseFeatureLocked "Server Assignment"...
```

Review it with `git diff -w` and it is a short read.

## `EnterpriseFeatureLocked` had no callers left

Those two dead branches were its only ones, and its CTA pointed at the same deleted licence page — so it rendered a button to a 404 inside a branch that could never render. Gone, and with it the `Loader2`, `Lock`, `Link`, `Button`, `Card*` and `api` imports that existed only to serve it.

`EnterpriseFeatureGate` **stays** as a documented pass-through. It still wraps five call sites across audit logs, custom roles, whitelabeling and SSO; unwrapping those would be JSX surgery in upstream files for no behavioural gain. Its `lockedProps` type is now inlined rather than `Omit<>`-ed from the deleted interface, so the two call sites that pass it still compile unchanged.

## Checks

- `bun run --filter dokploy typecheck` — 0 errors
- `biome check` — clean on all three files
- No source file outside these three touched; nothing reformatted that was not already being edited