### PR TITLE
test: give bun test the database mock vitest already had

### DIFF
--- a/apps/dokploy/__test__/db-mock.ts
+++ b/apps/dokploy/__test__/db-mock.ts
@@ -1,0 +1,53 @@
+/**
+ * The stand-in for `@dokploy/server/db`, shared by both test runners.
+ *
+ * Tests that import from the `@dokploy/server` barrel pull in `lib/auth` and
+ * `db`, which open a TCP connection to PostgreSQL on import. In CI there is no
+ * database, so that surfaces as ECONNREFUSED before a single assertion runs.
+ *
+ * Both runners install this, and each has to do it its own way - vitest through
+ * `setupFiles` and a hoisted `vi.mock`, bun through a `bunfig.toml` preload and
+ * `mock.module`. The shape they install is this function, so it only exists in
+ * one place.
+ */
+/** Both `vi.fn` and `jest.fn` satisfy this: they wrap an implementation and
+ * hand back something callable. The precise mock type differs per runner and
+ * nothing here depends on it. */
+type AnyFn = (...args: never[]) => unknown;
+type MockFn = (impl: AnyFn) => AnyFn;
+
+export const createDbMock = (fn: MockFn) => {
+	const chain = () => chain;
+	chain.set = () => chain;
+	chain.where = () => chain;
+	chain.values = () => chain;
+	chain.returning = () => Promise.resolve([{}]);
+	chain.from = () => chain;
+	chain.innerJoin = () => chain;
+	chain.then = (resolve: (value: unknown) => void) => {
+		resolve([]);
+	};
+
+	const tableMock = {
+		findFirst: fn(() => Promise.resolve(undefined)),
+		findMany: fn(() => Promise.resolve([])),
+		insert: fn(() => Promise.resolve([{}])),
+		update: fn(() => chain),
+		delete: fn(() => chain),
+	};
+
+	return {
+		db: {
+			select: fn(() => chain),
+			insert: fn(() => ({
+				values: () => ({ returning: () => Promise.resolve([{}]) }),
+			})),
+			update: fn(() => chain),
+			delete: fn(() => chain),
+			query: new Proxy({} as Record<string, typeof tableMock>, {
+				get: () => tableMock,
+			}),
+		},
+		dbUrl: "postgres://mock:mock@localhost:5432/mock",
+	};
+};

--- a/apps/dokploy/__test__/setup.bun.ts
+++ b/apps/dokploy/__test__/setup.bun.ts
@@ -1,0 +1,12 @@
+import { jest, mock } from "bun:test";
+import { createDbMock } from "./db-mock";
+
+/**
+ * Installed via `bunfig.toml` preload, which is the bun equivalent of vitest's
+ * `setupFiles`. Running before any test module loads is what makes this work:
+ * `mock.module` is not hoisted, so calling it from inside a test file would be
+ * too late for a database connection opened at import time.
+ *
+ * See ./db-mock.ts for why the mock exists at all.
+ */
+mock.module("@dokploy/server/db", () => createDbMock(jest.fn));

--- a/apps/dokploy/__test__/setup.ts
+++ b/apps/dokploy/__test__/setup.ts
@@ -1,43 +1,13 @@
 import { vi } from "vitest";
 
 /**
- * Mock the DB module so tests that import from @dokploy/server (barrel)
- * never open a real TCP connection to PostgreSQL (e.g. in CI where no DB runs).
- * Without this, loading the server barrel pulls in lib/auth and db, which
- * connect to localhost:5432 and cause ECONNREFUSED.
+ * Installed via vitest's `setupFiles`. See ./db-mock.ts for why the mock exists
+ * and for the bun-side counterpart.
+ *
+ * The factory is imported dynamically because `vi.mock` is hoisted above the
+ * import statements, so a top-level binding would not be initialised yet.
  */
-vi.mock("@dokploy/server/db", () => {
-	const chain = () => chain;
-	chain.set = () => chain;
-	chain.where = () => chain;
-	chain.values = () => chain;
-	chain.returning = () => Promise.resolve([{}]);
-	chain.from = () => chain;
-	chain.innerJoin = () => chain;
-	chain.then = (resolve: (value: unknown) => void) => {
-		resolve([]);
-	};
-
-	const tableMock = {
-		findFirst: vi.fn(() => Promise.resolve(undefined)),
-		findMany: vi.fn(() => Promise.resolve([])),
-		insert: vi.fn(() => Promise.resolve([{}])),
-		update: vi.fn(() => chain),
-		delete: vi.fn(() => chain),
-	};
-
-	return {
-		db: {
-			select: vi.fn(() => chain),
-			insert: vi.fn(() => ({
-				values: () => ({ returning: () => Promise.resolve([{}]) }),
-			})),
-			update: vi.fn(() => chain),
-			delete: vi.fn(() => chain),
-			query: new Proxy({} as Record<string, typeof tableMock>, {
-				get: () => tableMock,
-			}),
-		},
-		dbUrl: "postgres://mock:mock@localhost:5432/mock",
-	};
+vi.mock("@dokploy/server/db", async () => {
+	const { createDbMock } = await import("./db-mock");
+	return createDbMock(vi.fn);
 });

--- a/apps/dokploy/bunfig.toml
+++ b/apps/dokploy/bunfig.toml
@@ -1,0 +1,3 @@
+[test]
+# The bun-side equivalent of vitest's `setupFiles`; see __test__/db-mock.ts.
+preload = ["./__test__/setup.bun.ts"]


### PR DESCRIPTION
Found while looking at what blocks the next batch of test ports.

## The gap

`__test__/setup.ts` mocks `@dokploy/server/db` so tests importing the `@dokploy/server` barrel do not open a TCP connection to PostgreSQL at import time — in CI there is no database, so it surfaces as `ECONNREFUSED` before a single assertion runs.

vitest installs it via `setupFiles`. **Bun had no equivalent** — there was no `bunfig.toml` in the repo at all. So the twelve directories already on `bun test` have been running without that protection.

Nothing is failing today, which is exactly why it is easy to miss: those suites either never reach the barrel or mock the db themselves. But the guard vitest has, bun did not, and **every directory ported from here on inherits the gap**.

## The change

- `apps/dokploy/bunfig.toml` — `[test] preload`. Running before any test module loads is the whole point: `mock.module` is not hoisted, so installing this from inside a test file would already be too late for a connection opened at import time.
- `__test__/db-mock.ts` — the mock shape, in one place instead of duplicated per runner.
- `__test__/setup.bun.ts` — bun side, `mock.module` + `jest.fn`.
- `__test__/setup.ts` — vitest side, now calling the shared factory. It imports it **dynamically inside the factory**, because `vi.mock` is hoisted above the import statements and a top-level binding would not be initialised yet.

## Verification

The preload could easily be silently ignored, so it was checked rather than assumed — a probe importing from the barrel:

```ts
expect(dbUrl).toBe("postgres://mock:mock@localhost:5432/mock");   // ✓
await expect(db.query.anything.findMany()).resolves.toEqual([]);  // ✓ via the Proxy
```

| | before | after |
|---|---|---|
| `bun test` | 270 pass | 270 pass |
| `vitest` | 595 pass, 4 fail | 595 pass, 4 fail |
| `typecheck` | 0 errors | 0 errors |

The 4 vitest failures are the pre-existing `application.real.test.ts` ones needing an active swarm — CI initialises swarm explicitly, so they pass there.

Both runners were re-run after the `setup.ts` refactor specifically to confirm it is behaviour-neutral.

## Why this is its own PR

It touches every bun test at once. Landing it separately from a batch of ported directories means that if something does regress, the cause is unambiguous.