### PR TITLE
test: port server and permissions suites to bun:test

### DIFF
--- a/apps/dokploy/__test__/permissions/check-permission.test.ts
+++ b/apps/dokploy/__test__/permissions/check-permission.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, jest, mock } from "bun:test";
 
 const mockMemberData = (
 	role: string,
@@ -28,16 +28,16 @@ const mockMemberData = (
 let memberToReturn: ReturnType<typeof mockMemberData> =
 	mockMemberData("member");
 
-vi.mock("@dokploy/server/db", () => ({
+mock.module("@dokploy/server/db", () => ({
 	db: {
 		query: {
 			member: {
-				findFirst: vi.fn(() => Promise.resolve(memberToReturn)),
-				findMany: vi.fn(() => Promise.resolve([])),
+				findFirst: jest.fn(() => Promise.resolve(memberToReturn)),
+				findMany: jest.fn(() => Promise.resolve([])),
 			},
 			organizationRole: {
-				findFirst: vi.fn(),
-				findMany: vi.fn(() => Promise.resolve([])),
+				findFirst: jest.fn(),
+				findMany: jest.fn(() => Promise.resolve([])),
 			},
 		},
 	},
@@ -51,7 +51,7 @@ const ctx = {
 };
 
 beforeEach(() => {
-	vi.clearAllMocks();
+	jest.clearAllMocks();
 });
 
 describe("owner and admin bypass enterprise resources", () => {

--- a/apps/dokploy/__test__/permissions/enterprise-only-resources.test.ts
+++ b/apps/dokploy/__test__/permissions/enterprise-only-resources.test.ts
@@ -1,8 +1,8 @@
+import { describe, expect, it } from "bun:test";
 import {
 	enterpriseOnlyResources,
 	statements,
 } from "@dokploy/server/lib/access-control";
-import { describe, expect, it } from "vitest";
 
 const FREE_TIER_RESOURCES = [
 	"organization",

--- a/apps/dokploy/__test__/permissions/resolve-permissions.test.ts
+++ b/apps/dokploy/__test__/permissions/resolve-permissions.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, jest, mock } from "bun:test";
 
 const mockMemberData = (
 	role: string,
@@ -28,16 +28,16 @@ const mockMemberData = (
 let memberToReturn: ReturnType<typeof mockMemberData> =
 	mockMemberData("member");
 
-vi.mock("@dokploy/server/db", () => ({
+mock.module("@dokploy/server/db", () => ({
 	db: {
 		query: {
 			member: {
-				findFirst: vi.fn(() => Promise.resolve(memberToReturn)),
-				findMany: vi.fn(() => Promise.resolve([])),
+				findFirst: jest.fn(() => Promise.resolve(memberToReturn)),
+				findMany: jest.fn(() => Promise.resolve([])),
 			},
 			organizationRole: {
-				findFirst: vi.fn(),
-				findMany: vi.fn(() => Promise.resolve([])),
+				findFirst: jest.fn(),
+				findMany: jest.fn(() => Promise.resolve([])),
 			},
 		},
 	},
@@ -56,7 +56,7 @@ const ctx = {
 };
 
 beforeEach(() => {
-	vi.clearAllMocks();
+	jest.clearAllMocks();
 });
 
 describe("enterprise resources for static roles", () => {

--- a/apps/dokploy/__test__/permissions/service-access.test.ts
+++ b/apps/dokploy/__test__/permissions/service-access.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, jest, mock } from "bun:test";
 
 const mockMemberData = (
 	role: string,
@@ -29,16 +29,16 @@ const mockMemberData = (
 let memberToReturn: ReturnType<typeof mockMemberData> =
 	mockMemberData("member");
 
-vi.mock("@dokploy/server/db", () => ({
+mock.module("@dokploy/server/db", () => ({
 	db: {
 		query: {
 			member: {
-				findFirst: vi.fn(() => Promise.resolve(memberToReturn)),
-				findMany: vi.fn(() => Promise.resolve([])),
+				findFirst: jest.fn(() => Promise.resolve(memberToReturn)),
+				findMany: jest.fn(() => Promise.resolve([])),
 			},
 			organizationRole: {
-				findFirst: vi.fn(),
-				findMany: vi.fn(() => Promise.resolve([])),
+				findFirst: jest.fn(),
+				findMany: jest.fn(() => Promise.resolve([])),
 			},
 		},
 	},
@@ -54,7 +54,7 @@ const ctx = {
 };
 
 beforeEach(() => {
-	vi.clearAllMocks();
+	jest.clearAllMocks();
 });
 
 describe("checkServicePermissionAndAccess", () => {

--- a/apps/dokploy/__test__/server/mechanizeDockerContainer.test.ts
+++ b/apps/dokploy/__test__/server/mechanizeDockerContainer.test.ts
@@ -1,6 +1,6 @@
+import { beforeEach, describe, expect, it, jest, mock } from "bun:test";
 import type { ApplicationNested } from "@dokploy/server/utils/builders";
 import { mechanizeDockerContainer } from "@dokploy/server/utils/builders";
-import { beforeEach, describe, expect, it, vi } from "vitest";
 
 type MockCreateServiceOptions = {
 	TaskTemplate?: {
@@ -12,26 +12,20 @@ type MockCreateServiceOptions = {
 	[key: string]: unknown;
 };
 
-const { inspectMock, getServiceMock, createServiceMock, getRemoteDockerMock } =
-	vi.hoisted(() => {
-		const inspect = vi.fn<() => Promise<never>>();
-		const getService = vi.fn(() => ({ inspect }));
-		const createService = vi.fn<
-			(opts: MockCreateServiceOptions) => Promise<void>
-		>(async () => undefined);
-		const getRemoteDocker = vi.fn(async () => ({
-			getService,
-			createService,
-		}));
-		return {
-			inspectMock: inspect,
-			getServiceMock: getService,
-			createServiceMock: createService,
-			getRemoteDockerMock: getRemoteDocker,
-		};
-	});
+// `vi.hoisted` existed only to make these reachable from a hoisted `vi.mock`
+// factory. `mock.module` runs in source order, so plain consts declared above
+// the call are enough.
+const inspectMock = jest.fn<() => Promise<never>>();
+const getServiceMock = jest.fn(() => ({ inspect: inspectMock }));
+const createServiceMock = jest.fn<
+	(opts: MockCreateServiceOptions) => Promise<void>
+>(async () => undefined);
+const getRemoteDockerMock = jest.fn(async () => ({
+	getService: getServiceMock,
+	createService: createServiceMock,
+}));
 
-vi.mock("@dokploy/server/utils/servers/remote-docker", () => ({
+mock.module("@dokploy/server/utils/servers/remote-docker", () => ({
 	getRemoteDocker: getRemoteDockerMock,
 }));
 

--- a/apps/dokploy/__test__/server/server-health-subnet.test.ts
+++ b/apps/dokploy/__test__/server/server-health-subnet.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, test } from "bun:test";
 import { getSubnetCapacity } from "@dokploy/server/services/server-health";
-import { describe, expect, test } from "vitest";
 
 describe("getSubnetCapacity", () => {
 	test("returns null for missing/invalid input", () => {

--- a/apps/dokploy/__test__/server/server-setup.test.ts
+++ b/apps/dokploy/__test__/server/server-setup.test.ts
@@ -1,9 +1,9 @@
+import { describe, expect, it } from "bun:test";
 import { execFileSync, execSync } from "node:child_process";
 import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { defaultCommand, reportDockerVersion } from "@dokploy/server";
-import { describe, expect, it } from "vitest";
 
 const resolveBin = (name: string) =>
 	execSync(`command -v ${name}`, { encoding: "utf8" }).trim();

--- a/apps/dokploy/__test__/server/server-sshkey-redaction.test.ts
+++ b/apps/dokploy/__test__/server/server-sshkey-redaction.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, it } from "bun:test";
 import { redactServerSshKey } from "@dokploy/server/services/server";
-import { describe, expect, it } from "vitest";
 
 describe("redactServerSshKey (server SSH private key disclosure guard)", () => {
 	it("blanks the private key while keeping the rest of the ssh key intact", () => {

--- a/apps/dokploy/__test__/server/swarm-nodeid-injection.test.ts
+++ b/apps/dokploy/__test__/server/swarm-nodeid-injection.test.ts
@@ -1,7 +1,7 @@
+import { describe, expect, it } from "bun:test";
 import { execSync } from "node:child_process";
 import { existsSync, rmSync } from "node:fs";
 import { quote } from "shell-quote";
-import { describe, expect, it } from "vitest";
 
 // Mirrors how getNodeInfo builds its command in services/docker.ts:
 //   `docker node inspect ${quote([nodeId])} --format '{{json .}}'`

--- a/apps/dokploy/__test__/vitest.config.ts
+++ b/apps/dokploy/__test__/vitest.config.ts
@@ -23,6 +23,8 @@ export default defineConfig({
 			"**/__test__/queues/**",
 			"**/__test__/drop/**",
 			"**/__test__/traefik/**",
+			"**/__test__/server/**",
+			"**/__test__/permissions/**",
 		],
 		pool: "forks",
 		setupFiles: [path.resolve(__dirname, "setup.ts")],

--- a/apps/dokploy/package.json
+++ b/apps/dokploy/package.json
@@ -37,7 +37,7 @@
 		"docker:push:canary": "./docker/push.sh canary",
 		"version": "echo $(node -p \"require('./package.json').version\")",
 		"test": "bun run test:bun && bun run test:vitest",
-		"test:bun": "bun test __test__/logs __test__/registry __test__/requests __test__/api __test__/cluster __test__/templates __test__/backups __test__/services __test__/utils __test__/queues __test__/drop __test__/traefik",
+		"test:bun": "bun test __test__/logs __test__/registry __test__/requests __test__/api __test__/cluster __test__/templates __test__/backups __test__/services __test__/utils __test__/queues __test__/drop __test__/traefik __test__/server __test__/permissions",
 		"test:vitest": "vitest --config __test__/vitest.config.ts",
 		"generate:openapi": "bun scripts/generate-openapi.ts"
 	},


### PR DESCRIPTION
Second batch, on top of the preload from #26. `bun test` goes **24 → 33 files**, leaving 6 directories on vitest.

## What each needed

**`server/mechanizeDockerContainer.test.ts`** used `vi.hoisted()`. That helper exists so mocks are reachable from a *hoisted* `vi.mock` factory — `mock.module` runs in source order, so the wrapper buys nothing. The mocks are now plain consts declared above the call: same behaviour, less ceremony.

**`permissions`** needed no restructuring. Its db mock reads `memberToReturn` from a closure at call time, and the variable is declared above the mock, so the ordering trap that bit `drop` in #22 does not arise here.

## Sabotage results — including two that proved nothing

This is the directory CLAUDE.md warns about, where the suite once stayed green straight through a fundamental behaviour change. So it got three attempts, and the first two are worth recording because **both left all 45 tests passing**:

| Sabotage | Result | Why |
|---|---|---|
| `hasPermission` catch → `return true` (deny becomes allow) | **45 pass** | That function has **no coverage at all** |
| `isPrivilegedStaticRole` → `false` | **45 pass** | Only skips an early return; owner/admin still resolve to a privileged role below it, so behaviour genuinely does not change |
| `checkPermission` returns before any check | **11 fail** | ✅ port confirmed |

The middle row is a fair sabotage that correctly changed nothing. The **first row is a real coverage gap**: the suite calls `checkPermission` (21 sites) and `resolvePermissions` (13) and never `hasPermission` — the boolean wrapper whose failure silently grants access. Pre-existing, not introduced here, and flagged separately rather than smuggled into this PR.

`server` was verified the same way: forcing `StopGracePeriod` to a constant produced 1 failure.

## Checks

| | |
|---|---|
| `bun test` | 334 pass, 0 fail, 33 files |
| `vitest` | 531 pass, same 4 pre-existing swarm failures |
| `typecheck` | 0 errors, all four packages |

Both lists updated together as always. Formatting applied to the nine edited files only.