### PR TITLE
test: port wss and dns suites to bun:test

### DIFF
--- a/apps/dokploy/__test__/dns/cloudflare.test.ts
+++ b/apps/dokploy/__test__/dns/cloudflare.test.ts
@@ -1,6 +1,6 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, jest, mock } from "bun:test";
 
-const mockFetch = vi.fn();
+const mockFetch = jest.fn();
 global.fetch = mockFetch as unknown as typeof fetch;
 
 import { cloudflareClient } from "@dokploy/server/utils/dns/cloudflare";

--- a/apps/dokploy/__test__/dns/dns-provider-service.test.ts
+++ b/apps/dokploy/__test__/dns/dns-provider-service.test.ts
@@ -1,11 +1,11 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, jest, mock } from "bun:test";
 
-vi.mock("@dokploy/server/db", () => ({
+mock.module("@dokploy/server/db", () => ({
 	db: {
-		query: { dnsProvider: { findFirst: vi.fn(), findMany: vi.fn() } },
-		insert: vi.fn(),
-		update: vi.fn(),
-		delete: vi.fn(),
+		query: { dnsProvider: { findFirst: jest.fn(), findMany: jest.fn() } },
+		insert: jest.fn(),
+		update: jest.fn(),
+		delete: jest.fn(),
 	},
 }));
 

--- a/apps/dokploy/__test__/dns/route53.test.ts
+++ b/apps/dokploy/__test__/dns/route53.test.ts
@@ -1,36 +1,26 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, jest, mock } from "bun:test";
 
 type HasInput = { input: any };
 
-const {
-	send,
-	Route53Client,
-	ListHostedZonesCommand,
-	ListResourceRecordSetsCommand,
-	ChangeResourceRecordSetsCommand,
-} = vi.hoisted(() => {
-	class FakeCommand {
-		input: any;
-		constructor(input: any) {
-			this.input = input;
-		}
+// `vi.hoisted` wrapped these so the hoisted `vi.mock` factory below could see
+// them. `mock.module` runs in source order, so top-level declarations do.
+class FakeCommand {
+	input: any;
+	constructor(input: any) {
+		this.input = input;
 	}
-	const send = vi.fn();
-	class Route53Client {
-		send(command: unknown) {
-			return send(command);
-		}
+}
+const send = jest.fn();
+class Route53Client {
+	send(command: unknown) {
+		return send(command);
 	}
-	return {
-		send,
-		Route53Client,
-		ListHostedZonesCommand: class extends FakeCommand {},
-		ListResourceRecordSetsCommand: class extends FakeCommand {},
-		ChangeResourceRecordSetsCommand: class extends FakeCommand {},
-	};
-});
+}
+class ListHostedZonesCommand extends FakeCommand {}
+class ListResourceRecordSetsCommand extends FakeCommand {}
+class ChangeResourceRecordSetsCommand extends FakeCommand {}
 
-vi.mock("@aws-sdk/client-route-53", () => ({
+mock.module("@aws-sdk/client-route-53", () => ({
 	Route53Client,
 	ListHostedZonesCommand,
 	ListResourceRecordSetsCommand,

--- a/apps/dokploy/__test__/vitest.config.ts
+++ b/apps/dokploy/__test__/vitest.config.ts
@@ -25,6 +25,8 @@ export default defineConfig({
 			"**/__test__/traefik/**",
 			"**/__test__/server/**",
 			"**/__test__/permissions/**",
+			"**/__test__/wss/**",
+			"**/__test__/dns/**",
 		],
 		pool: "forks",
 		setupFiles: [path.resolve(__dirname, "setup.ts")],

--- a/apps/dokploy/__test__/wss/authorize.test.ts
+++ b/apps/dokploy/__test__/wss/authorize.test.ts
@@ -1,17 +1,17 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, jest, mock } from "bun:test";
 
 // Mock the permission + server helpers the wss authorizer composes.
-const mockHasPermission = vi.hoisted(() => vi.fn());
-const mockFindMember = vi.hoisted(() => vi.fn());
-const mockCheckServiceAccess = vi.hoisted(() => vi.fn());
-vi.mock("@dokploy/server/services/permission", () => ({
+const mockHasPermission = jest.fn();
+const mockFindMember = jest.fn();
+const mockCheckServiceAccess = jest.fn();
+mock.module("@dokploy/server/services/permission", () => ({
 	hasPermission: mockHasPermission,
 	findMemberByUserId: mockFindMember,
 	checkServiceAccess: mockCheckServiceAccess,
 }));
 
-const mockGetAccessibleServerIds = vi.hoisted(() => vi.fn());
-vi.mock("@dokploy/server", () => ({
+const mockGetAccessibleServerIds = jest.fn();
+mock.module("@dokploy/server", () => ({
 	getAccessibleServerIds: mockGetAccessibleServerIds,
 }));
 
@@ -24,7 +24,7 @@ const USER = { id: "user-1" };
 const SESSION = { activeOrganizationId: "org-1" };
 
 beforeEach(() => {
-	vi.clearAllMocks();
+	jest.clearAllMocks();
 });
 
 describe("canAccessDockerOverWss", () => {

--- a/apps/dokploy/__test__/wss/readValidDirectory.test.ts
+++ b/apps/dokploy/__test__/wss/readValidDirectory.test.ts
@@ -1,21 +1,22 @@
+import { describe, expect, it, mock } from "bun:test";
 import path from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import * as constants from "@dokploy/server/constants";
 
 const BASE = "/base";
 
-vi.mock("@dokploy/server/constants", async (importOriginal) => {
-	const actual =
-		await importOriginal<typeof import("@dokploy/server/constants")>();
-	return {
-		...actual,
-		paths: () => ({
-			...actual.paths(),
-			BASE_PATH: BASE,
-			LOGS_PATH: `${BASE}/logs`,
-			APPLICATIONS_PATH: `${BASE}/applications`,
-		}),
-	};
-});
+// Snapshot before mocking: `mock.module` has no `importOriginal`, and reading
+// through the namespace afterwards would recurse into the mock.
+const actual = { ...constants };
+
+mock.module("@dokploy/server/constants", () => ({
+	...actual,
+	paths: () => ({
+		...actual.paths(),
+		BASE_PATH: BASE,
+		LOGS_PATH: `${BASE}/logs`,
+		APPLICATIONS_PATH: `${BASE}/applications`,
+	}),
+}));
 
 // Import after mock so paths() uses our BASE
 const { readValidDirectory } = await import("@dokploy/server");

--- a/apps/dokploy/__test__/wss/utils.test.ts
+++ b/apps/dokploy/__test__/wss/utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "bun:test";
 import {
 	isValidContainerId,
 	isValidSearch,

--- a/apps/dokploy/package.json
+++ b/apps/dokploy/package.json
@@ -37,7 +37,7 @@
 		"docker:push:canary": "./docker/push.sh canary",
 		"version": "echo $(node -p \"require('./package.json').version\")",
 		"test": "bun run test:bun && bun run test:vitest",
-		"test:bun": "bun test __test__/logs __test__/registry __test__/requests __test__/api __test__/cluster __test__/templates __test__/backups __test__/services __test__/utils __test__/queues __test__/drop __test__/traefik __test__/server __test__/permissions",
+		"test:bun": "bun test __test__/logs __test__/registry __test__/requests __test__/api __test__/cluster __test__/templates __test__/backups __test__/services __test__/utils __test__/queues __test__/drop __test__/traefik __test__/server __test__/permissions __test__/wss __test__/dns",
 		"test:vitest": "vitest --config __test__/vitest.config.ts",
 		"generate:openapi": "bun scripts/generate-openapi.ts"
 	},


### PR DESCRIPTION
Third batch. `bun test` goes **33 → 39 files**, leaving four directories on vitest: `compose`, `deploy`, `git-provider`, `env`.

## Two patterns, both already seen

**`importOriginal`** — `wss/readValidDirectory.test.ts` is the same shape as `drop` in #22. `mock.module` has no `importOriginal`, and reading back through the namespace *after* mocking would recurse into the mock, so the namespace is snapshotted into a plain object first.

Safe to port either way here, unlike `drop`: the test asserts against its own `BASE` constant and touches no filesystem, so a mock that failed to apply would fail loudly rather than delete something.

**`vi.hoisted`** — `wss/authorize.test.ts` and `dns/route53.test.ts`. That helper only exists to make values reachable from a *hoisted* `vi.mock` factory. `mock.module` runs in source order, so the wrapper buys nothing. route53's fake AWS command classes go from a block returning an object that is immediately destructured, to ordinary top-level class declarations:

```diff
-const { send, Route53Client, ListHostedZonesCommand, ... } = vi.hoisted(() => {
-	class FakeCommand { ... }
-	return { ..., ListHostedZonesCommand: class extends FakeCommand {} };
-});
+class FakeCommand { ... }
+class ListHostedZonesCommand extends FakeCommand {}
```

## Sabotage

| Sabotage | Result |
|---|---|
| `readValidDirectory` forced to `return true` | 6 failures |
| route53 `listZones` returning `[]` | 2 failures |

Sources restored; the diff contains no source changes.

## Checks

| | |
|---|---|
| `bun test` | 404 pass, 0 fail, 39 files |
| `vitest` | 461 pass, same 4 pre-existing swarm failures |
| `typecheck` | 0 errors, all four packages |

Both lists updated together. Formatting applied only to the six edited files.