### PR TITLE
test: port the compose suite to bun:test

### DIFF
--- a/apps/dokploy/__test__/compose/build-compose-command.test.ts
+++ b/apps/dokploy/__test__/compose/build-compose-command.test.ts
@@ -1,11 +1,22 @@
-import { describe, expect, it, jest, mock } from "bun:test";
+import { afterAll, describe, expect, it, jest, mock } from "bun:test";
 import { getBuildComposeCommand } from "@dokploy/server/utils/builders/compose";
+import * as domainModule from "@dokploy/server/utils/docker/domain";
 
 // Isolate the command builder from the compose-file I/O performed by
 // writeDomainsToCompose; we only care about the docker invocation it emits.
+// Snapshot and restore: `mock.module` is process-global, so without the
+// `afterAll` this stub replaces `writeDomainsToCompose` for every later file in
+// the same `bun test` run - which is exactly how it broke
+// domain-command-injection.test.ts, whose assertions depend on the real one.
+const actualDomain = { ...domainModule };
 mock.module("@dokploy/server/utils/docker/domain", () => ({
+	...actualDomain,
 	writeDomainsToCompose: jest.fn().mockResolvedValue(""),
 }));
+
+afterAll(() => {
+	mock.module("@dokploy/server/utils/docker/domain", () => actualDomain);
+});
 
 const baseCompose = {
 	appName: "my-app",

--- a/apps/dokploy/__test__/compose/build-compose-command.test.ts
+++ b/apps/dokploy/__test__/compose/build-compose-command.test.ts
@@ -1,10 +1,10 @@
+import { describe, expect, it, jest, mock } from "bun:test";
 import { getBuildComposeCommand } from "@dokploy/server/utils/builders/compose";
-import { describe, expect, it, vi } from "vitest";
 
 // Isolate the command builder from the compose-file I/O performed by
 // writeDomainsToCompose; we only care about the docker invocation it emits.
-vi.mock("@dokploy/server/utils/docker/domain", () => ({
-	writeDomainsToCompose: vi.fn().mockResolvedValue(""),
+mock.module("@dokploy/server/utils/docker/domain", () => ({
+	writeDomainsToCompose: jest.fn().mockResolvedValue(""),
 }));
 
 const baseCompose = {

--- a/apps/dokploy/__test__/compose/compose-command-injection.test.ts
+++ b/apps/dokploy/__test__/compose/compose-command-injection.test.ts
@@ -1,8 +1,8 @@
+import { describe, expect, it } from "bun:test";
 import { execSync } from "node:child_process";
 import { existsSync, rmSync } from "node:fs";
 import { createCommand } from "@dokploy/server/utils/builders/compose";
 import { parse, quote } from "shell-quote";
-import { describe, expect, it } from "vitest";
 
 const MARK = `/tmp/dokploy_compose_pwned_${process.pid}`;
 

--- a/apps/dokploy/__test__/compose/compose.test.ts
+++ b/apps/dokploy/__test__/compose/compose.test.ts
@@ -1,6 +1,6 @@
+import { expect, test } from "bun:test";
 import type { ComposeSpecification } from "@dokploy/server";
 import { addSuffixToAllProperties } from "@dokploy/server";
-import { expect, test } from "vitest";
 import { parse } from "yaml";
 
 const composeFile1 = `

--- a/apps/dokploy/__test__/compose/config/config-root.test.ts
+++ b/apps/dokploy/__test__/compose/config/config-root.test.ts
@@ -1,6 +1,6 @@
+import { expect, test } from "bun:test";
 import type { ComposeSpecification } from "@dokploy/server";
 import { addSuffixToConfigsRoot, generateRandomHash } from "@dokploy/server";
-import { expect, test } from "vitest";
 import { parse } from "yaml";
 
 test("Generate random hash with 8 characters", () => {
@@ -170,7 +170,7 @@ test("Add suffix to configs in root property", () => {
 		return;
 	}
 	const configs = addSuffixToConfigsRoot(composeData.configs, suffix);
-	const updatedComposeData = { ...composeData, configs };
+	const updatedComposeData: ComposeSpecification = { ...composeData, configs };
 
 	// Verificar que el resultado coincide con el archivo esperado
 	expect(updatedComposeData).toEqual(expectedComposeFileConfigRoot);

--- a/apps/dokploy/__test__/compose/config/config-service.test.ts
+++ b/apps/dokploy/__test__/compose/config/config-service.test.ts
@@ -1,9 +1,9 @@
+import { expect, test } from "bun:test";
 import type { ComposeSpecification } from "@dokploy/server";
 import {
 	addSuffixToConfigsInServices,
 	generateRandomHash,
 } from "@dokploy/server";
-import { expect, test } from "vitest";
 import { parse } from "yaml";
 
 const composeFile = `
@@ -193,7 +193,10 @@ test("Add suffix to configs in services", () => {
 		composeData.services,
 		suffix,
 	);
-	const actualComposeData = { ...composeData, services: updatedComposeData };
+	const actualComposeData: ComposeSpecification = {
+		...composeData,
+		services: updatedComposeData,
+	};
 
 	expect(actualComposeData).toEqual(expectedComposeFileConfigServices);
 });

--- a/apps/dokploy/__test__/compose/config/config.test.ts
+++ b/apps/dokploy/__test__/compose/config/config.test.ts
@@ -1,6 +1,6 @@
+import { expect, test } from "bun:test";
 import type { ComposeSpecification } from "@dokploy/server";
 import { addSuffixToAllConfigs, generateRandomHash } from "@dokploy/server";
-import { expect, test } from "vitest";
 import { parse } from "yaml";
 
 test("Generate random hash with 8 characters", () => {

--- a/apps/dokploy/__test__/compose/domain-command-injection.test.ts
+++ b/apps/dokploy/__test__/compose/domain-command-injection.test.ts
@@ -24,7 +24,13 @@ afterAll(() => {
 	mock.module("node:fs", () => ({ ...actualFs, default: actualFs }));
 });
 
-import { writeDomainsToCompose } from "@dokploy/server/utils/docker/domain";
+// Imported dynamically, after the mock. A static import is hoisted, and by the
+// time `mock.module` runs the module under test has already bound `existsSync`
+// from the real `node:fs` - for a native builtin that binding does not update.
+// `vi.mock` did not need this because it was hoisted above the imports.
+const { writeDomainsToCompose } = await import(
+	"@dokploy/server/utils/docker/domain"
+);
 
 const baseCompose = {
 	appName: "my-app",

--- a/apps/dokploy/__test__/compose/domain-command-injection.test.ts
+++ b/apps/dokploy/__test__/compose/domain-command-injection.test.ts
@@ -1,16 +1,27 @@
+import { afterAll, describe, expect, it, mock } from "bun:test";
+import * as nodeFs from "node:fs";
 import { parse } from "shell-quote";
-import { describe, expect, it, vi } from "vitest";
+
+// Snapshot before mocking: `mock.module` has no `importOriginal`, and reading
+// back through the namespace afterwards would recurse into the mock.
+const actualFs = { ...nodeFs };
 
 // writeDomainsToCompose reads the on-disk compose file; mock fs so the file
 // "exists" but does not contain the attacker's service, forcing the error path
 // whose message embeds the user-controlled serviceName.
-vi.mock("node:fs", async (importOriginal) => {
-	const actual = await importOriginal<typeof import("node:fs")>();
-	return {
-		...actual,
-		existsSync: () => true,
-		readFileSync: () => "services:\n  web:\n    image: nginx\n",
-	};
+mock.module("node:fs", () => ({
+	...actualFs,
+	default: actualFs,
+	existsSync: () => true,
+	readFileSync: () => "services:\n  web:\n    image: nginx\n",
+}));
+
+// `mock.module` is process-global and `mock.restore()` does not undo it, so
+// without this the fake `existsSync` leaks into every later file in the same
+// `bun test` run. vitest never needed it - `pool: "forks"` gives each file its
+// own module registry. Re-installing the snapshot is what actually reverts it.
+afterAll(() => {
+	mock.module("node:fs", () => ({ ...actualFs, default: actualFs }));
 });
 
 import { writeDomainsToCompose } from "@dokploy/server/utils/docker/domain";

--- a/apps/dokploy/__test__/compose/domain/enabled-filter.test.ts
+++ b/apps/dokploy/__test__/compose/domain/enabled-filter.test.ts
@@ -1,7 +1,7 @@
+import { beforeEach, describe, expect, it, jest } from "bun:test";
 import type { Compose } from "@dokploy/server/services/compose";
 import type { Domain } from "@dokploy/server/services/domain";
 import { addDomainToCompose } from "@dokploy/server/utils/docker/domain";
-import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // With sourceType "raw", addDomainToCompose parses compose.composeFile
 // directly instead of reading from disk, so baseCompose exposes it as a
@@ -56,7 +56,7 @@ const serviceLabels = (
 
 describe("addDomainToCompose enabled filtering", () => {
 	beforeEach(() => {
-		vi.clearAllMocks();
+		jest.clearAllMocks();
 		composeYaml = baseComposeYaml;
 	});
 

--- a/apps/dokploy/__test__/compose/domain/host-rule-format.test.ts
+++ b/apps/dokploy/__test__/compose/domain/host-rule-format.test.ts
@@ -1,6 +1,6 @@
+import { describe, expect, it } from "bun:test";
 import type { Domain } from "@dokploy/server";
 import { createDomainLabels } from "@dokploy/server";
-import { describe, expect, it } from "vitest";
 import { parse, stringify } from "yaml";
 
 /**

--- a/apps/dokploy/__test__/compose/domain/labels.test.ts
+++ b/apps/dokploy/__test__/compose/domain/labels.test.ts
@@ -1,6 +1,6 @@
+import { describe, expect, it } from "bun:test";
 import type { Domain } from "@dokploy/server";
 import { createDomainLabels } from "@dokploy/server";
-import { describe, expect, it } from "vitest";
 
 describe("createDomainLabels", () => {
 	const appName = "test-app";

--- a/apps/dokploy/__test__/compose/domain/network-root.test.ts
+++ b/apps/dokploy/__test__/compose/domain/network-root.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, it } from "bun:test";
 import { addDokployNetworkToRoot } from "@dokploy/server";
-import { describe, expect, it } from "vitest";
 
 describe("addDokployNetworkToRoot", () => {
 	it("should create network object if networks is undefined", () => {

--- a/apps/dokploy/__test__/compose/domain/network-service.test.ts
+++ b/apps/dokploy/__test__/compose/domain/network-service.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, it } from "bun:test";
 import { addDokployNetworkToService } from "@dokploy/server";
-import { describe, expect, it } from "vitest";
 
 describe("addDokployNetworkToService", () => {
 	it("should add network to an empty array", () => {

--- a/apps/dokploy/__test__/compose/domain/raw-compose.test.ts
+++ b/apps/dokploy/__test__/compose/domain/raw-compose.test.ts
@@ -1,17 +1,20 @@
+import { describe, expect, it, jest, mock } from "bun:test";
 import { addDomainToCompose } from "@dokploy/server/utils/docker/domain";
-import { execAsyncRemote } from "@dokploy/server/utils/process/execAsync";
-import { describe, expect, it, vi } from "vitest";
+import * as execAsyncModule from "@dokploy/server/utils/process/execAsync";
 
-vi.mock("@dokploy/server/utils/process/execAsync", async (importOriginal) => ({
-	...(await importOriginal<
-		typeof import("@dokploy/server/utils/process/execAsync")
-	>()),
-	execAsyncRemote: vi.fn(),
+// Snapshot before mocking, then keep a handle on the replacement rather than
+// reaching for it through `vi.mocked` afterwards.
+const actualExecAsync = { ...execAsyncModule };
+const execAsyncRemoteMock = jest.fn();
+
+mock.module("@dokploy/server/utils/process/execAsync", () => ({
+	...actualExecAsync,
+	execAsyncRemote: execAsyncRemoteMock,
 }));
 
 describe("raw remote compose conversion (#4794)", () => {
 	it("uses the saved raw source and preserves supported mount syntax", async () => {
-		vi.mocked(execAsyncRemote).mockResolvedValue({
+		execAsyncRemoteMock.mockResolvedValue({
 			stdout: "services:\n  test:\n    image: alpine:latest\n",
 			stderr: "",
 		});
@@ -54,6 +57,6 @@ volumes:
 			},
 		]);
 		expect(converted?.services?.test?.tmpfs).toEqual(["/cache"]);
-		expect(execAsyncRemote).not.toHaveBeenCalled();
+		expect(execAsyncRemoteMock).not.toHaveBeenCalled();
 	});
 });

--- a/apps/dokploy/__test__/compose/env-file-literals.test.ts
+++ b/apps/dokploy/__test__/compose/env-file-literals.test.ts
@@ -1,8 +1,8 @@
+import { afterEach, describe, expect, it } from "bun:test";
 import { execFileSync } from "node:child_process";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { getCreateEnvFileCommand } from "@dokploy/server/utils/builders/compose";
-import { afterEach, describe, expect, it } from "vitest";
 
 // Regression coverage for https://github.com/Dokploy/dokploy/issues/4694 —
 // values must survive Docker Compose's own `.env` parsing, not just base64 decode.

--- a/apps/dokploy/__test__/compose/env-file-preserved.test.ts
+++ b/apps/dokploy/__test__/compose/env-file-preserved.test.ts
@@ -1,12 +1,23 @@
-import { describe, expect, it, jest, mock } from "bun:test";
+import { afterAll, describe, expect, it, jest, mock } from "bun:test";
 import { getBuildComposeCommand } from "@dokploy/server/utils/builders/compose";
+import * as domainModule from "@dokploy/server/utils/docker/domain";
 
 // Compose now has a `createEnvFile` toggle (default true), mirroring the
 // Application builder's flag: when disabled, Dokploy never writes `.env`,
 // so a repo-tracked file survives untouched.
+// Snapshot and restore: `mock.module` is process-global, so without the
+// `afterAll` this stub replaces `writeDomainsToCompose` for every later file in
+// the same `bun test` run - which is exactly how it broke
+// domain-command-injection.test.ts, whose assertions depend on the real one.
+const actualDomain = { ...domainModule };
 mock.module("@dokploy/server/utils/docker/domain", () => ({
+	...actualDomain,
 	writeDomainsToCompose: jest.fn().mockResolvedValue(""),
 }));
+
+afterAll(() => {
+	mock.module("@dokploy/server/utils/docker/domain", () => actualDomain);
+});
 
 const baseCompose = {
 	appName: "env-file-toggle",

--- a/apps/dokploy/__test__/compose/env-file-preserved.test.ts
+++ b/apps/dokploy/__test__/compose/env-file-preserved.test.ts
@@ -1,11 +1,11 @@
+import { describe, expect, it, jest, mock } from "bun:test";
 import { getBuildComposeCommand } from "@dokploy/server/utils/builders/compose";
-import { describe, expect, it, vi } from "vitest";
 
 // Compose now has a `createEnvFile` toggle (default true), mirroring the
 // Application builder's flag: when disabled, Dokploy never writes `.env`,
 // so a repo-tracked file survives untouched.
-vi.mock("@dokploy/server/utils/docker/domain", () => ({
-	writeDomainsToCompose: vi.fn().mockResolvedValue(""),
+mock.module("@dokploy/server/utils/docker/domain", () => ({
+	writeDomainsToCompose: jest.fn().mockResolvedValue(""),
 }));
 
 const baseCompose = {

--- a/apps/dokploy/__test__/compose/network/network-root.test.ts
+++ b/apps/dokploy/__test__/compose/network/network-root.test.ts
@@ -1,6 +1,6 @@
+import { expect, test } from "bun:test";
 import type { ComposeSpecification } from "@dokploy/server";
 import { addSuffixToNetworksRoot, generateRandomHash } from "@dokploy/server";
-import { expect, test } from "vitest";
 import { parse } from "yaml";
 
 const composeFile = `
@@ -273,10 +273,13 @@ test("Add suffix to networks with static suffix", () => {
 	}
 	const networks = addSuffixToNetworksRoot(composeData.networks, suffix);
 
-	const expectedComposeData = parse(
+	const { networks: expectedNetworks } = parse(
 		expectedComposeFile6,
 	) as ComposeSpecification;
-	expect(networks).toStrictEqual(expectedComposeData.networks);
+	if (!expectedNetworks) {
+		throw new Error("fixture expectedComposeFile6 has no networks");
+	}
+	expect(networks).toStrictEqual(expectedNetworks);
 });
 
 const composeFile7 = `

--- a/apps/dokploy/__test__/compose/network/network-service.test.ts
+++ b/apps/dokploy/__test__/compose/network/network-service.test.ts
@@ -1,9 +1,9 @@
+import { expect, test } from "bun:test";
 import type { ComposeSpecification } from "@dokploy/server";
 import {
 	addSuffixToServiceNetworks,
 	generateRandomHash,
 } from "@dokploy/server";
-import { expect, test } from "vitest";
 import { parse } from "yaml";
 
 const composeFile = `

--- a/apps/dokploy/__test__/compose/network/network.test.ts
+++ b/apps/dokploy/__test__/compose/network/network.test.ts
@@ -1,3 +1,4 @@
+import { expect, test } from "bun:test";
 import type { ComposeSpecification } from "@dokploy/server";
 import {
 	addSuffixToAllNetworks,
@@ -5,7 +6,6 @@ import {
 	addSuffixToServiceNetworks,
 	generateRandomHash,
 } from "@dokploy/server";
-import { expect, test } from "vitest";
 import { parse } from "yaml";
 
 const composeFileCombined = `

--- a/apps/dokploy/__test__/compose/network/service-networks.test.ts
+++ b/apps/dokploy/__test__/compose/network/service-networks.test.ts
@@ -1,14 +1,29 @@
+import { afterAll, beforeEach, expect, jest, mock, test } from "bun:test";
 import type { Compose, ComposeSpecification } from "@dokploy/server";
 import {
 	applyServiceNetworks,
 	declareUsedNetworksInRoot,
 	resolveServiceNetworks,
 } from "@dokploy/server";
-import { db } from "@dokploy/server/db";
-import { beforeEach, expect, test, type vi } from "vitest";
 import { parse } from "yaml";
+import { createDbMock } from "../../db-mock";
 
-const findManyMock = db.query.network.findMany as ReturnType<typeof vi.fn>;
+// This used to reach into the preload's shared db mock. `mock.module` is
+// process-global, so any other file in the same `bun test` run that mocks
+// `@dokploy/server/db` with a narrower shape - queues and permissions both do -
+// replaced it and left `db.query.network` undefined. Owning the mock here makes
+// the file independent of which other files ran first.
+const findManyMock = jest.fn();
+
+mock.module("@dokploy/server/db", () => ({
+	db: { query: { network: { findMany: findManyMock } } },
+}));
+
+// Same reasoning in reverse: this narrow shape would leak to every later file.
+// Put the preload's shape back on the way out.
+afterAll(() => {
+	mock.module("@dokploy/server/db", () => createDbMock(jest.fn));
+});
 
 beforeEach(() => {
 	findManyMock.mockReset();

--- a/apps/dokploy/__test__/compose/secrets/secret-root.test.ts
+++ b/apps/dokploy/__test__/compose/secrets/secret-root.test.ts
@@ -1,6 +1,6 @@
+import { expect, test } from "bun:test";
 import type { ComposeSpecification } from "@dokploy/server";
 import { addSuffixToSecretsRoot, generateRandomHash } from "@dokploy/server";
-import { expect, test } from "vitest";
 import { parse } from "yaml";
 
 test("Generate random hash with 8 characters", () => {

--- a/apps/dokploy/__test__/compose/secrets/secret-services.test.ts
+++ b/apps/dokploy/__test__/compose/secrets/secret-services.test.ts
@@ -1,9 +1,9 @@
+import { expect, test } from "bun:test";
 import type { ComposeSpecification } from "@dokploy/server";
 import {
 	addSuffixToSecretsInServices,
 	generateRandomHash,
 } from "@dokploy/server";
-import { expect, test } from "vitest";
 import { parse } from "yaml";
 
 const composeFileSecretsServices = `

--- a/apps/dokploy/__test__/compose/secrets/secret.test.ts
+++ b/apps/dokploy/__test__/compose/secrets/secret.test.ts
@@ -1,6 +1,6 @@
+import { expect, test } from "bun:test";
 import type { ComposeSpecification } from "@dokploy/server";
 import { addSuffixToAllSecrets } from "@dokploy/server";
-import { expect, test } from "vitest";
 import { parse } from "yaml";
 
 const composeFileCombinedSecrets = `

--- a/apps/dokploy/__test__/compose/service/service-container-name.test.ts
+++ b/apps/dokploy/__test__/compose/service/service-container-name.test.ts
@@ -1,6 +1,6 @@
+import { expect, test } from "bun:test";
 import type { ComposeSpecification } from "@dokploy/server";
 import { addSuffixToServiceNames, generateRandomHash } from "@dokploy/server";
-import { expect, test } from "vitest";
 import { parse } from "yaml";
 
 const composeFile = `

--- a/apps/dokploy/__test__/compose/service/service-depends-on.test.ts
+++ b/apps/dokploy/__test__/compose/service/service-depends-on.test.ts
@@ -1,6 +1,6 @@
+import { expect, test } from "bun:test";
 import type { ComposeSpecification } from "@dokploy/server";
 import { addSuffixToServiceNames, generateRandomHash } from "@dokploy/server";
-import { expect, test } from "vitest";
 import { parse } from "yaml";
 
 test("Generate random hash with 8 characters", () => {

--- a/apps/dokploy/__test__/compose/service/service-extends.test.ts
+++ b/apps/dokploy/__test__/compose/service/service-extends.test.ts
@@ -1,6 +1,6 @@
+import { expect, test } from "bun:test";
 import type { ComposeSpecification } from "@dokploy/server";
 import { addSuffixToServiceNames, generateRandomHash } from "@dokploy/server";
-import { expect, test } from "vitest";
 import { parse } from "yaml";
 
 test("Generate random hash with 8 characters", () => {

--- a/apps/dokploy/__test__/compose/service/service-links.test.ts
+++ b/apps/dokploy/__test__/compose/service/service-links.test.ts
@@ -1,6 +1,6 @@
+import { expect, test } from "bun:test";
 import type { ComposeSpecification } from "@dokploy/server";
 import { addSuffixToServiceNames, generateRandomHash } from "@dokploy/server";
-import { expect, test } from "vitest";
 import { parse } from "yaml";
 
 test("Generate random hash with 8 characters", () => {

--- a/apps/dokploy/__test__/compose/service/service-names.test.ts
+++ b/apps/dokploy/__test__/compose/service/service-names.test.ts
@@ -1,6 +1,6 @@
+import { expect, test } from "bun:test";
 import type { ComposeSpecification } from "@dokploy/server";
 import { addSuffixToServiceNames, generateRandomHash } from "@dokploy/server";
-import { expect, test } from "vitest";
 import { parse } from "yaml";
 
 test("Generate random hash with 8 characters", () => {

--- a/apps/dokploy/__test__/compose/service/service-volumes-from.test.ts
+++ b/apps/dokploy/__test__/compose/service/service-volumes-from.test.ts
@@ -1,6 +1,6 @@
+import { expect, test } from "bun:test";
 import type { ComposeSpecification } from "@dokploy/server";
 import { addSuffixToServiceNames, generateRandomHash } from "@dokploy/server";
-import { expect, test } from "vitest";
 import { parse } from "yaml";
 
 test("Generate random hash with 8 characters", () => {

--- a/apps/dokploy/__test__/compose/service/service.test.ts
+++ b/apps/dokploy/__test__/compose/service/service.test.ts
@@ -1,9 +1,9 @@
+import { expect, test } from "bun:test";
 import type { ComposeSpecification } from "@dokploy/server";
 import {
 	addSuffixToAllServiceNames,
 	addSuffixToServiceNames,
 } from "@dokploy/server";
-import { expect, test } from "vitest";
 import { parse } from "yaml";
 
 const composeFileCombinedAllCases = `

--- a/apps/dokploy/__test__/compose/volume/volume-2.test.ts
+++ b/apps/dokploy/__test__/compose/volume/volume-2.test.ts
@@ -1,10 +1,10 @@
+import { expect, test } from "bun:test";
 import type { ComposeSpecification } from "@dokploy/server";
 import {
 	addSuffixToAllVolumes,
 	addSuffixToVolumesRoot,
 	generateRandomHash,
 } from "@dokploy/server";
-import { expect, test } from "vitest";
 import { parse } from "yaml";
 
 const composeFile = `
@@ -318,7 +318,7 @@ services:
     container_name: supabase-kong
     image: kong:2.8.1
     restart: unless-stopped
-    entrypoint: bash -c 'eval "echo \"$$(cat ~/temp.yml)\"" > ~/kong.yml && /docker-entrypoint.sh kong docker-start'
+    entrypoint: bash -c 'eval "echo "$$(cat ~/temp.yml)"" > ~/kong.yml && /docker-entrypoint.sh kong docker-start'
     ports:
       - \${KONG_HTTP_PORT}:8000/tcp
       - \${KONG_HTTPS_PORT}:8443/tcp
@@ -684,7 +684,7 @@ services:
     container_name: supabase-kong
     image: kong:2.8.1
     restart: unless-stopped
-    entrypoint: bash -c 'eval "echo \"$$(cat ~/temp.yml)\"" > ~/kong.yml && /docker-entrypoint.sh kong docker-start'
+    entrypoint: bash -c 'eval "echo "$$(cat ~/temp.yml)"" > ~/kong.yml && /docker-entrypoint.sh kong docker-start'
     ports:
       - \${KONG_HTTP_PORT}:8000/tcp
       - \${KONG_HTTPS_PORT}:8443/tcp

--- a/apps/dokploy/__test__/compose/volume/volume-root.test.ts
+++ b/apps/dokploy/__test__/compose/volume/volume-root.test.ts
@@ -1,6 +1,6 @@
+import { expect, test } from "bun:test";
 import type { ComposeSpecification } from "@dokploy/server";
 import { addSuffixToVolumesRoot, generateRandomHash } from "@dokploy/server";
-import { expect, test } from "vitest";
 import { parse } from "yaml";
 
 const composeFile = `
@@ -187,7 +187,7 @@ test("Add suffix to volumes in root property", () => {
 		return;
 	}
 	const volumes = addSuffixToVolumesRoot(composeData.volumes, suffix);
-	const updatedComposeData = { ...composeData, volumes };
+	const updatedComposeData: ComposeSpecification = { ...composeData, volumes };
 
 	// Verificar que el resultado coincide con el archivo esperado
 	expect(updatedComposeData).toEqual(expectedComposeFile4);

--- a/apps/dokploy/__test__/compose/volume/volume-services.test.ts
+++ b/apps/dokploy/__test__/compose/volume/volume-services.test.ts
@@ -1,9 +1,9 @@
+import { expect, test } from "bun:test";
 import type { ComposeSpecification } from "@dokploy/server";
 import {
 	addSuffixToVolumesInServices,
 	generateRandomHash,
 } from "@dokploy/server";
-import { expect, test } from "vitest";
 import { parse } from "yaml";
 
 test("Generate random hash with 8 characters", () => {

--- a/apps/dokploy/__test__/compose/volume/volume.test.ts
+++ b/apps/dokploy/__test__/compose/volume/volume.test.ts
@@ -1,6 +1,6 @@
+import { expect, test } from "bun:test";
 import type { ComposeSpecification } from "@dokploy/server";
 import { addSuffixToAllVolumes } from "@dokploy/server";
-import { expect, test } from "vitest";
 import { parse } from "yaml";
 
 const composeFileTypeVolume = `

--- a/apps/dokploy/__test__/vitest.config.ts
+++ b/apps/dokploy/__test__/vitest.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
 			"**/__test__/permissions/**",
 			"**/__test__/wss/**",
 			"**/__test__/dns/**",
+			"**/__test__/compose/**",
 		],
 		pool: "forks",
 		setupFiles: [path.resolve(__dirname, "setup.ts")],

--- a/apps/dokploy/package.json
+++ b/apps/dokploy/package.json
@@ -37,7 +37,7 @@
 		"docker:push:canary": "./docker/push.sh canary",
 		"version": "echo $(node -p \"require('./package.json').version\")",
 		"test": "bun run test:bun && bun run test:vitest",
-		"test:bun": "bun test __test__/logs __test__/registry __test__/requests __test__/api __test__/cluster __test__/templates __test__/backups __test__/services __test__/utils __test__/queues __test__/drop __test__/traefik __test__/server __test__/permissions __test__/wss __test__/dns",
+		"test:bun": "bun test __test__/logs __test__/registry __test__/requests __test__/api __test__/cluster __test__/templates __test__/backups __test__/services __test__/utils __test__/queues __test__/drop __test__/traefik __test__/server __test__/permissions __test__/wss __test__/dns __test__/compose",
 		"test:vitest": "vitest --config __test__/vitest.config.ts",
 		"generate:openapi": "bun scripts/generate-openapi.ts"
 	},


### PR DESCRIPTION
Largest batch yet: **33 files**. `bun test` goes 39 → 72 files, 404 → 587 tests. Three directories left on vitest: `deploy`, `git-provider`, `env`.

27 files were a straight import rewrite. Six needed real work, and two of them surfaced something the earlier batches never hit.

## `mock.module` is process-global — vitest was hiding that

vitest runs with `pool: "forks"`, so each test file gets its **own module registry** and a module mock physically cannot escape the file that declared it. `bun test` runs the files in one process, so it can — and here it did, twice:

**1. `node:fs` leaked across files.** `domain-command-injection.test.ts` mocks `node:fs` with `existsSync: () => true`. That bled into `compose-command-injection.test.ts`:

```
bun test compose-command-injection.test.ts                    → 13 pass
bun test domain-command-injection.test.ts compose-command-...  → 12 pass, 3 fail
```

A suite that passes or fails depending on which files ran alongside it — the worst kind of flake, because the file itself looks fine.

**2. The shared db mock got replaced.** `network/service-networks.test.ts` read `db.query.network.findMany` from the preload installed in #26. But `queues` and `permissions` both replace `@dokploy/server/db` with a *narrower* shape, so by the time this file ran, `db.query.network` was `undefined`. It passed alone and failed in the full run.

### `mock.restore()` does not fix this

Measured rather than assumed:

```ts
mock.module("node:fs", () => ({ ...actual, existsSync: () => true }));
mock.restore();
nodeFs.existsSync("/nope")   // → still true
mock.module("node:fs", () => ({ ...actual, default: actual }));
nodeFs.existsSync("/nope")   // → false
```

**Re-installing the original module is what actually reverts it.** So the fs mock now restores the snapshot in `afterAll`, and `service-networks` owns its db mock outright and puts the preload's shape back on the way out.

## Stricter matcher typing

Four files hit `toEqual` requiring the expected value to match the received type — vitest did not. Fixed by typing the values as the `ComposeSpecification` they already are. In `network-root` the fixture side was genuinely `| undefined`, so it got a real guard instead:

```ts
if (!expectedNetworks) {
	throw new Error("fixture expectedComposeFile6 has no networks");
}
```

No casts, no `@ts-ignore` — and the fixture assumption now fails loudly instead of silently comparing against `undefined`.

## Verification

Sabotage: removing the shell quoting from the `stack deploy` command → 1 failure. Source restored; the diff contains no source changes.

| | |
|---|---|
| `bun test` | 587 pass, 0 fail, 72 files |
| `vitest` | 278 pass, same 4 pre-existing swarm failures |
| `typecheck` | 0 errors, all four packages |

Both lists updated together. Formatting applied only to the 33 files this PR already edits.

## Worth knowing before the next port

`queues/concurrency.test.ts` and the three `permissions` files also replace `@dokploy/server/db` process-wide without restoring it. Nothing fails today — ordering happens to work out — but it is the same landmine. Left alone here rather than widening this diff.