### PR TITLE
test: port the git-provider suite to bun:test

### DIFF
--- a/apps/dokploy/__test__/git-provider/git-clone-command-injection.test.ts
+++ b/apps/dokploy/__test__/git-provider/git-clone-command-injection.test.ts
@@ -1,6 +1,6 @@
+import { describe, expect, it } from "bun:test";
 import { cloneGitRepository } from "@dokploy/server/utils/providers/git";
 import { parse, quote } from "shell-quote";
-import { describe, expect, it } from "vitest";
 
 // How git-provider commands escape a single user value before it reaches the shell.
 const shellArg = (value: string) => quote([String(value ?? "")]);

--- a/apps/dokploy/__test__/git-provider/git-provider-access.test.ts
+++ b/apps/dokploy/__test__/git-provider/git-provider-access.test.ts
@@ -1,22 +1,38 @@
 import {
+	afterAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	jest,
+	mock,
+} from "bun:test";
+import {
 	canEditDeployGitSource,
 	getAccessibleGitProviderIds,
 } from "@dokploy/server/services/git-provider";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDbMock } from "../db-mock";
 
-const mockDb = vi.hoisted(() => ({
+const mockDb = {
 	query: {
 		gitProvider: {
-			findMany: vi.fn(),
-			findFirst: vi.fn(),
+			findMany: jest.fn(),
+			findFirst: jest.fn(),
 		},
 		member: {
-			findFirst: vi.fn(),
+			findFirst: jest.fn(),
 		},
 	},
-}));
+};
 
-vi.mock("@dokploy/server/db", () => ({ db: mockDb }));
+mock.module("@dokploy/server/db", () => ({ db: mockDb }));
+
+// Put the preload's shape back: `mock.module` is process-global, and this
+// narrow stub would otherwise leave `db` without the tables every later file
+// expects. See __test__/db-mock.ts.
+afterAll(() => {
+	mock.module("@dokploy/server/db", () => createDbMock(jest.fn));
+});
 
 const ORG_ID = "org-1";
 const USER_OWNER = "user-owner";
@@ -57,7 +73,7 @@ function session(userId: string) {
 }
 
 beforeEach(() => {
-	vi.clearAllMocks();
+	jest.clearAllMocks();
 	mockDb.query.gitProvider.findMany.mockResolvedValue(allProviders);
 });
 
@@ -204,7 +220,7 @@ describe("getAccessibleGitProviderIds", () => {
 
 describe("canEditDeployGitSource", () => {
 	beforeEach(() => {
-		vi.clearAllMocks();
+		jest.clearAllMocks();
 	});
 
 	describe("owner", () => {

--- a/apps/dokploy/__test__/git-provider/git-provider-idor.test.ts
+++ b/apps/dokploy/__test__/git-provider/git-provider-idor.test.ts
@@ -1,20 +1,37 @@
+import {
+	afterAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	jest,
+	mock,
+} from "bun:test";
 import { TRPCError } from "@trpc/server";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDbMock } from "../db-mock";
 
 // Mock the DB so the REAL getAccessibleGitProviderIds (called internally by
 // assertGitProviderAccess) runs against controlled data. Mocking the exported
 // function would NOT intercept the intra-module call, so we mock one layer down.
-const mockDb = vi.hoisted(() => ({
+const mockDb = {
 	query: {
 		gitProvider: {
-			findMany: vi.fn(),
+			findMany: jest.fn(),
 		},
 		member: {
-			findFirst: vi.fn(),
+			findFirst: jest.fn(),
 		},
 	},
-}));
-vi.mock("@dokploy/server/db", () => ({ db: mockDb }));
+};
+
+mock.module("@dokploy/server/db", () => ({ db: mockDb }));
+
+// Put the preload's shape back: `mock.module` is process-global, and this
+// narrow stub would otherwise leave `db` without the tables every later file
+// expects. See __test__/db-mock.ts.
+afterAll(() => {
+	mock.module("@dokploy/server/db", () => createDbMock(jest.fn));
+});
 
 import { assertGitProviderAccess } from "@dokploy/server/services/git-provider";
 
@@ -36,7 +53,7 @@ const providerOther = {
 };
 
 beforeEach(() => {
-	vi.clearAllMocks();
+	jest.clearAllMocks();
 	mockDb.query.gitProvider.findMany.mockResolvedValue([
 		providerMine,
 		providerOther,

--- a/apps/dokploy/__test__/git-provider/github-clone-host.test.ts
+++ b/apps/dokploy/__test__/git-provider/github-clone-host.test.ts
@@ -1,22 +1,49 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	afterAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	jest,
+	mock,
+} from "bun:test";
+import * as githubService from "@dokploy/server/services/github";
+import * as authApp from "@octokit/auth-app";
+import * as octokitModule from "octokit";
 
 // cloneGithubRepository builds a shell command; the only thing under test here
 // is which host ends up in the clone URL, so the app auth is stubbed out.
-const mockFindGithubById = vi.hoisted(() => vi.fn());
+const mockFindGithubById = jest.fn();
 
-vi.mock("@dokploy/server/services/github", () => ({
+// Snapshot each module before replacing it. `mock.module` is process-global and
+// `mock.restore()` does not undo it, so every stub here has to be put back or it
+// changes the behaviour of every later file in the same `bun test` run.
+const actualGithubService = { ...githubService };
+const actualAuthApp = { ...authApp };
+const actualOctokit = { ...octokitModule };
+
+mock.module("@dokploy/server/services/github", () => ({
+	...actualGithubService,
 	findGithubById: mockFindGithubById,
 }));
 
-vi.mock("@octokit/auth-app", () => ({
-	createAppAuth: vi.fn(),
+mock.module("@octokit/auth-app", () => ({
+	...actualAuthApp,
+	createAppAuth: jest.fn(),
 }));
 
-vi.mock("octokit", () => ({
+mock.module("octokit", () => ({
+	...actualOctokit,
 	Octokit: class {
 		auth = async () => ({ token: "gh-token" });
 	},
 }));
+
+afterAll(() => {
+	mock.module("@dokploy/server/services/github", () => actualGithubService);
+	mock.module("@octokit/auth-app", () => actualAuthApp);
+	mock.module("octokit", () => actualOctokit);
+});
 
 const { cloneGithubRepository } = await import(
 	"@dokploy/server/utils/providers/github"
@@ -45,7 +72,7 @@ const clone = async () => {
 
 describe("cloneGithubRepository host", () => {
 	beforeEach(() => {
-		vi.clearAllMocks();
+		jest.clearAllMocks();
 	});
 
 	it("clones from github.com for a default provider", async () => {

--- a/apps/dokploy/__test__/git-provider/github-enterprise-url.test.ts
+++ b/apps/dokploy/__test__/git-provider/github-enterprise-url.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "bun:test";
 import {
 	DEFAULT_GITHUB_API_URL,
 	DEFAULT_GITHUB_URL,
@@ -5,7 +6,6 @@ import {
 	normalizeGithubUrl,
 	parseGithubBaseUrl,
 } from "@dokploy/server/utils/providers/github";
-import { describe, expect, it } from "vitest";
 
 const urlOf = (result: ReturnType<typeof parseGithubBaseUrl>) =>
 	"url" in result ? result.url : null;

--- a/apps/dokploy/__test__/git-provider/github-setup-handler.test.ts
+++ b/apps/dokploy/__test__/git-provider/github-setup-handler.test.ts
@@ -1,26 +1,50 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	afterAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	jest,
+	mock,
+} from "bun:test";
+import * as serverBarrel from "@dokploy/server";
+import * as permissionModule from "@dokploy/server/services/permission";
+import * as octokitModule from "octokit";
 
 // The gh_init branch runs on a GET the user can be linked into, so a rejected
 // host must produce a 400 *before* any outbound request is made.
-const mockValidateRequest = vi.hoisted(() => vi.fn());
-const mockHasPermission = vi.hoisted(() => vi.fn());
-const mockCreateGithub = vi.hoisted(() => vi.fn());
-const mockOctokitRequest = vi.hoisted(() => vi.fn());
+const mockValidateRequest = jest.fn();
+const mockHasPermission = jest.fn();
+const mockCreateGithub = jest.fn();
+const mockOctokitRequest = jest.fn();
 
-vi.mock("@dokploy/server", async (importOriginal) => {
-	const actual = await importOriginal<typeof import("@dokploy/server")>();
-	return {
-		...actual,
-		validateRequest: mockValidateRequest,
-		createGithub: mockCreateGithub,
-	};
-});
+// Snapshot before mocking - there is no `importOriginal`, and reading back
+// through the namespace afterwards would recurse into the mock. The restores
+// matter more than usual here: this stubs the whole `@dokploy/server` barrel,
+// and `mock.module` outlives the file that called it.
+const actualBarrel = { ...serverBarrel };
+const actualPermission = { ...permissionModule };
+const actualOctokit = { ...octokitModule };
 
-vi.mock("@dokploy/server/services/permission", () => ({
+mock.module("@dokploy/server", () => ({
+	...actualBarrel,
+	validateRequest: mockValidateRequest,
+	createGithub: mockCreateGithub,
+}));
+
+mock.module("@dokploy/server/services/permission", () => ({
+	...actualPermission,
 	hasPermission: mockHasPermission,
 }));
 
-vi.mock("octokit", () => ({
+afterAll(() => {
+	mock.module("@dokploy/server", () => actualBarrel);
+	mock.module("@dokploy/server/services/permission", () => actualPermission);
+	mock.module("octokit", () => actualOctokit);
+});
+
+mock.module("octokit", () => ({
+	...actualOctokit,
 	Octokit: class {
 		request = mockOctokitRequest;
 	},
@@ -69,7 +93,7 @@ const call = async (githubUrl?: string | string[]) => {
 
 describe("github setup handler — host validation", () => {
 	beforeEach(() => {
-		vi.clearAllMocks();
+		jest.clearAllMocks();
 		mockValidateRequest.mockResolvedValue({
 			user: { id: USER },
 			session: { activeOrganizationId: ORG },

--- a/apps/dokploy/__test__/git-provider/github-url-parity.test.ts
+++ b/apps/dokploy/__test__/git-provider/github-url-parity.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, it } from "bun:test";
 import { parseGithubBaseUrl } from "@dokploy/server/utils/providers/github";
-import { describe, expect, it } from "vitest";
 import { DEFAULT_GITHUB_URL, resolveGithubBaseUrl } from "@/utils/github-utils";
 
 /**

--- a/apps/dokploy/__test__/vitest.config.ts
+++ b/apps/dokploy/__test__/vitest.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
 			"**/__test__/wss/**",
 			"**/__test__/dns/**",
 			"**/__test__/compose/**",
+			"**/__test__/git-provider/**",
 		],
 		pool: "forks",
 		setupFiles: [path.resolve(__dirname, "setup.ts")],

--- a/apps/dokploy/package.json
+++ b/apps/dokploy/package.json
@@ -37,7 +37,7 @@
 		"docker:push:canary": "./docker/push.sh canary",
 		"version": "echo $(node -p \"require('./package.json').version\")",
 		"test": "bun run test:bun && bun run test:vitest",
-		"test:bun": "bun test __test__/logs __test__/registry __test__/requests __test__/api __test__/cluster __test__/templates __test__/backups __test__/services __test__/utils __test__/queues __test__/drop __test__/traefik __test__/server __test__/permissions __test__/wss __test__/dns __test__/compose",
+		"test:bun": "bun test __test__/logs __test__/registry __test__/requests __test__/api __test__/cluster __test__/templates __test__/backups __test__/services __test__/utils __test__/queues __test__/drop __test__/traefik __test__/server __test__/permissions __test__/wss __test__/dns __test__/compose __test__/git-provider",
 		"test:vitest": "vitest --config __test__/vitest.config.ts",
 		"generate:openapi": "bun scripts/generate-openapi.ts"
 	},


### PR DESCRIPTION
Second-to-last directory. 7 files, and the most mock-heavy in the repo — **8 module mocks** across `@dokploy/server` (the whole barrel), `@dokploy/server/db`, `.../services/github`, `.../services/permission`, `octokit` and `@octokit/auth-app`.

## Every mock is restored, and that is the point

Each one is snapshotted before mocking and put back in `afterAll`. That is not defensive habit — it is the fix for exactly what broke #29 in CI: a stub of a shared module **outlives the file that installed it**, and the next file to touch that module gets the stub instead of the real thing.

Stubbing the `@dokploy/server` barrel process-wide without restoring would have been the widest version of that bug in this repo.

`vi.hoisted` is gone in both of its forms — the `() => vi.fn()` shorthand and the object literal in the two db tests — because `mock.module` runs in source order and the wrapper only ever existed to feed a hoisted factory.

## Verified three ways

#29 taught me that a green directory proves very little, so:

| Check | Result |
|---|---|
| Each of the 7 files run **individually** | 0 failures |
| Full suite with **git-provider first**, so a leaking barrel stub would hit every other directory | 455 pass, 0 fail |
| Sabotage: `getAccessibleGitProviderIds` returns an empty set | **10 failures** |

Source restored; the diff contains no source changes.

The middle row is the one that matters here. In the normal `test:bun` order git-provider runs last, where a leak would be invisible — so it was deliberately moved to the front to make one visible if it existed.

## Checks

| | |
|---|---|
| `bun test` | 680 pass, 0 fail, 79 files |
| `vitest` | 185 pass, same 4 pre-existing swarm failures |
| `typecheck` | 0 errors, all four packages |

## What is left after this

`deploy` and `env`.

`env` stays blocked on `vi.resetModules()` — measured, no bun equivalent, and the cache-busting workaround does not work.

`deploy` holds `application.real.test.ts`, the four tests that need an active Docker swarm. CI initialises swarm before the test job so they pass there, but they cannot be verified locally without `docker swarm init`, which changes the host daemon globally. Worth doing deliberately rather than unattended.