### PR TITLE
test: port the deploy suite to bun:test

### DIFF
--- a/apps/dokploy/__test__/deploy/application.command.test.ts
+++ b/apps/dokploy/__test__/deploy/application.command.test.ts
@@ -1,21 +1,64 @@
+import {
+	afterAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	jest,
+	mock,
+} from "bun:test";
 import * as adminService from "@dokploy/server/services/admin";
 import * as applicationService from "@dokploy/server/services/application";
 import { deployApplication } from "@dokploy/server/services/application";
 import * as deploymentService from "@dokploy/server/services/deployment";
+import * as rollbacksService from "@dokploy/server/services/rollbacks";
 import * as builders from "@dokploy/server/utils/builders";
+import * as buildError from "@dokploy/server/utils/notifications/build-error";
 import * as notifications from "@dokploy/server/utils/notifications/build-success";
 import * as execProcess from "@dokploy/server/utils/process/execAsync";
 import * as gitProvider from "@dokploy/server/utils/providers/git";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDbMock } from "../db-mock";
 
-vi.mock("@dokploy/server/db", () => {
+// Snapshot every module before mocking. `mock.module` has no `importActual`,
+// and reading back through a namespace after mocking recurses into the mock.
+// The restores at the bottom matter because `mock.module` is process-global.
+const actual = {
+	adminService: { ...adminService },
+	applicationService: { ...applicationService },
+	deploymentService: { ...deploymentService },
+	rollbacksService: { ...rollbacksService },
+	builders: { ...builders },
+	buildError: { ...buildError },
+	notifications: { ...notifications },
+	execProcess: { ...execProcess },
+	gitProvider: { ...gitProvider },
+};
+
+// Named handles instead of `vi.mocked(...)`, which bun:test has no equivalent
+// for. Referencing these directly is also better typed than casting.
+const findApplicationByIdMock = jest.fn();
+const updateApplicationStatusMock = jest.fn();
+const getDokployUrlMock = jest.fn();
+const createDeploymentMock = jest.fn();
+const updateDeploymentStatusMock = jest.fn();
+const updateDeploymentMock = jest.fn();
+const getGitCommitInfoMock = jest.fn();
+const execAsyncMock = jest.fn();
+const mechanizeDockerContainerMock = jest.fn();
+const getBuildCommandMock = jest.fn();
+const sendBuildSuccessNotificationsMock = jest.fn();
+const sendBuildErrorNotificationsMock = jest.fn();
+const createRollbackMock = jest.fn();
+const applicationsFindFirstMock = jest.fn();
+
+mock.module("@dokploy/server/db", () => {
 	const createChainableMock = (): any => {
 		const chain = {
-			set: vi.fn(() => chain),
-			where: vi.fn(() => chain),
-			returning: vi.fn().mockResolvedValue([{}] as any),
-			from: vi.fn(() => chain),
-			innerJoin: vi.fn(() => chain),
+			set: jest.fn(() => chain),
+			where: jest.fn(() => chain),
+			returning: jest.fn().mockResolvedValue([{}] as any),
+			from: jest.fn(() => chain),
+			innerJoin: jest.fn(() => chain),
 			then: (resolve: (v: any) => void) => {
 				resolve([]);
 			},
@@ -25,82 +68,73 @@ vi.mock("@dokploy/server/db", () => {
 
 	return {
 		db: {
-			select: vi.fn(() => createChainableMock()),
-			insert: vi.fn(),
-			update: vi.fn(() => createChainableMock()),
-			delete: vi.fn(),
+			select: jest.fn(() => createChainableMock()),
+			insert: jest.fn(),
+			update: jest.fn(() => createChainableMock()),
+			delete: jest.fn(),
 			query: {
 				applications: {
-					findFirst: vi.fn(),
+					findFirst: applicationsFindFirstMock,
 				},
 				patch: {
-					findMany: vi.fn().mockResolvedValue([]),
+					findMany: jest.fn().mockResolvedValue([]),
 				},
 				member: {
-					findMany: vi.fn().mockResolvedValue([]),
+					findMany: jest.fn().mockResolvedValue([]),
 				},
 			},
 		},
 	};
 });
 
-vi.mock("@dokploy/server/services/application", async () => {
-	const actual = await vi.importActual<
-		typeof import("@dokploy/server/services/application")
-	>("@dokploy/server/services/application");
-	return {
-		...actual,
-		findApplicationById: vi.fn(),
-		updateApplicationStatus: vi.fn(),
-	};
-});
-
-vi.mock("@dokploy/server/services/admin", () => ({
-	getDokployUrl: vi.fn(),
+mock.module("@dokploy/server/services/application", () => ({
+	...actual.applicationService,
+	findApplicationById: findApplicationByIdMock,
+	updateApplicationStatus: updateApplicationStatusMock,
 }));
 
-vi.mock("@dokploy/server/services/deployment", () => ({
-	createDeployment: vi.fn(),
-	updateDeploymentStatus: vi.fn(),
-	updateDeployment: vi.fn(),
+mock.module("@dokploy/server/services/admin", () => ({
+	...actual.adminService,
+	getDokployUrl: getDokployUrlMock,
 }));
 
-vi.mock("@dokploy/server/utils/providers/git", async () => {
-	const actual = await vi.importActual<
-		typeof import("@dokploy/server/utils/providers/git")
-	>("@dokploy/server/utils/providers/git");
-	return {
-		...actual,
-		getGitCommitInfo: vi.fn(),
-	};
-});
+mock.module("@dokploy/server/services/deployment", () => ({
+	...actual.deploymentService,
+	createDeployment: createDeploymentMock,
+	updateDeploymentStatus: updateDeploymentStatusMock,
+	updateDeployment: updateDeploymentMock,
+}));
 
-vi.mock("@dokploy/server/utils/process/execAsync", () => ({
-	execAsync: vi.fn(),
+mock.module("@dokploy/server/utils/providers/git", () => ({
+	...actual.gitProvider,
+	getGitCommitInfo: getGitCommitInfoMock,
+}));
+
+mock.module("@dokploy/server/utils/process/execAsync", () => ({
+	...actual.execProcess,
+	execAsync: execAsyncMock,
 	ExecError: class ExecError extends Error {},
 }));
 
-vi.mock("@dokploy/server/utils/builders", async () => {
-	const actual = await vi.importActual<
-		typeof import("@dokploy/server/utils/builders")
-	>("@dokploy/server/utils/builders");
-	return {
-		...actual,
-		mechanizeDockerContainer: vi.fn(),
-		getBuildCommand: vi.fn(),
-	};
-});
-
-vi.mock("@dokploy/server/utils/notifications/build-success", () => ({
-	sendBuildSuccessNotifications: vi.fn(),
+mock.module("@dokploy/server/utils/builders", () => ({
+	...actual.builders,
+	mechanizeDockerContainer: mechanizeDockerContainerMock,
+	getBuildCommand: getBuildCommandMock,
 }));
 
-vi.mock("@dokploy/server/utils/notifications/build-error", () => ({
-	sendBuildErrorNotifications: vi.fn(),
+mock.module("@dokploy/server/utils/notifications/build-success", () => ({
+	...actual.notifications,
+	sendBuildSuccessNotifications: sendBuildSuccessNotificationsMock,
 }));
 
-vi.mock("@dokploy/server/services/rollbacks", () => ({
-	createRollback: vi.fn(),
+mock.module("@dokploy/server/utils/notifications/build-error", () => ({
+	...actual.buildError,
+	sendBuildErrorNotifications: sendBuildErrorNotificationsMock,
+}));
+
+mock.module("@dokploy/server/services/rollbacks", () => ({
+	...actual.rollbacksService,
+	createRollback: createRollbackMock,
 }));
 
 import { db } from "@dokploy/server/db";
@@ -142,40 +176,24 @@ const createMockDeployment = () => ({
 
 describe("deployApplication - Command Generation Tests", () => {
 	beforeEach(() => {
-		vi.clearAllMocks();
-		vi.mocked(db.query.applications.findFirst).mockResolvedValue(
-			createMockApplication() as any,
-		);
-		vi.mocked(applicationService.findApplicationById).mockResolvedValue(
-			createMockApplication() as any,
-		);
-		vi.mocked(adminService.getDokployUrl).mockResolvedValue(
-			"http://localhost:3000",
-		);
-		vi.mocked(deploymentService.createDeployment).mockResolvedValue(
-			createMockDeployment() as any,
-		);
-		vi.mocked(execProcess.execAsync).mockResolvedValue({
+		jest.clearAllMocks();
+		applicationsFindFirstMock.mockResolvedValue(createMockApplication() as any);
+		findApplicationByIdMock.mockResolvedValue(createMockApplication() as any);
+		getDokployUrlMock.mockResolvedValue("http://localhost:3000");
+		createDeploymentMock.mockResolvedValue(createMockDeployment() as any);
+		execAsyncMock.mockResolvedValue({
 			stdout: "",
 			stderr: "",
 		} as any);
-		vi.mocked(builders.mechanizeDockerContainer).mockResolvedValue(
-			undefined as any,
-		);
-		vi.mocked(deploymentService.updateDeploymentStatus).mockResolvedValue(
-			undefined as any,
-		);
-		vi.mocked(applicationService.updateApplicationStatus).mockResolvedValue(
-			{} as any,
-		);
-		vi.mocked(notifications.sendBuildSuccessNotifications).mockResolvedValue(
-			undefined as any,
-		);
-		vi.mocked(gitProvider.getGitCommitInfo).mockResolvedValue({
+		mechanizeDockerContainerMock.mockResolvedValue(undefined as any);
+		updateDeploymentStatusMock.mockResolvedValue(undefined as any);
+		updateApplicationStatusMock.mockResolvedValue({} as any);
+		sendBuildSuccessNotificationsMock.mockResolvedValue(undefined as any);
+		getGitCommitInfoMock.mockResolvedValue({
 			message: "test commit",
 			hash: "abc123",
 		});
-		vi.mocked(deploymentService.updateDeployment).mockResolvedValue({} as any);
+		updateDeploymentMock.mockResolvedValue({} as any);
 	});
 
 	it("should generate correct git clone command for astro example", async () => {
@@ -200,7 +218,7 @@ describe("deployApplication - Command Generation Tests", () => {
 
 	it("should verify nixpacks command is called with correct app", async () => {
 		const mockNixpacksCommand = "nixpacks build /path/to/app --name test-app";
-		vi.mocked(builders.getBuildCommand).mockResolvedValue(mockNixpacksCommand);
+		getBuildCommandMock.mockResolvedValue(mockNixpacksCommand);
 
 		await deployApplication({
 			applicationId: "test-app-id",
@@ -223,15 +241,11 @@ describe("deployApplication - Command Generation Tests", () => {
 
 	it("should verify railpack command includes correct parameters", async () => {
 		const mockApp = createMockApplication({ buildType: "railpack" });
-		vi.mocked(db.query.applications.findFirst).mockResolvedValue(
-			mockApp as any,
-		);
-		vi.mocked(applicationService.findApplicationById).mockResolvedValue(
-			mockApp as any,
-		);
+		applicationsFindFirstMock.mockResolvedValue(mockApp as any);
+		findApplicationByIdMock.mockResolvedValue(mockApp as any);
 
 		const mockRailpackCommand = "railpack prepare /path/to/app";
-		vi.mocked(builders.getBuildCommand).mockResolvedValue(mockRailpackCommand);
+		getBuildCommandMock.mockResolvedValue(mockRailpackCommand);
 
 		await deployApplication({
 			applicationId: "test-app-id",
@@ -252,7 +266,7 @@ describe("deployApplication - Command Generation Tests", () => {
 
 	it("should execute commands in correct order", async () => {
 		const mockNixpacksCommand = "nixpacks build";
-		vi.mocked(builders.getBuildCommand).mockResolvedValue(mockNixpacksCommand);
+		getBuildCommandMock.mockResolvedValue(mockNixpacksCommand);
 
 		await deployApplication({
 			applicationId: "test-app-id",
@@ -260,7 +274,7 @@ describe("deployApplication - Command Generation Tests", () => {
 			descriptionLog: "",
 		});
 
-		const execCalls = vi.mocked(execProcess.execAsync).mock.calls;
+		const execCalls = execAsyncMock.mock.calls;
 		expect(execCalls.length).toBeGreaterThan(0);
 
 		const fullCommand = execCalls[0]?.[0];
@@ -271,7 +285,7 @@ describe("deployApplication - Command Generation Tests", () => {
 
 	it("should include log redirection in command", async () => {
 		const mockCommand = "nixpacks build";
-		vi.mocked(builders.getBuildCommand).mockResolvedValue(mockCommand);
+		getBuildCommandMock.mockResolvedValue(mockCommand);
 
 		await deployApplication({
 			applicationId: "test-app-id",
@@ -279,9 +293,40 @@ describe("deployApplication - Command Generation Tests", () => {
 			descriptionLog: "",
 		});
 
-		const execCalls = vi.mocked(execProcess.execAsync).mock.calls;
+		const execCalls = execAsyncMock.mock.calls;
 		const fullCommand = execCalls[0]?.[0];
 
 		expect(fullCommand).toContain(">> /tmp/test-deployment.log 2>&1");
 	});
+});
+
+afterAll(() => {
+	mock.module("@dokploy/server/db", () => createDbMock(jest.fn));
+	mock.module("@dokploy/server/services/admin", () => actual.adminService);
+	mock.module(
+		"@dokploy/server/services/application",
+		() => actual.applicationService,
+	);
+	mock.module(
+		"@dokploy/server/services/deployment",
+		() => actual.deploymentService,
+	);
+	mock.module(
+		"@dokploy/server/services/rollbacks",
+		() => actual.rollbacksService,
+	);
+	mock.module("@dokploy/server/utils/builders", () => actual.builders);
+	mock.module(
+		"@dokploy/server/utils/notifications/build-error",
+		() => actual.buildError,
+	);
+	mock.module(
+		"@dokploy/server/utils/notifications/build-success",
+		() => actual.notifications,
+	);
+	mock.module(
+		"@dokploy/server/utils/process/execAsync",
+		() => actual.execProcess,
+	);
+	mock.module("@dokploy/server/utils/providers/git", () => actual.gitProvider);
 });

--- a/apps/dokploy/__test__/deploy/application.real.test.ts
+++ b/apps/dokploy/__test__/deploy/application.real.test.ts
@@ -1,22 +1,59 @@
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	jest,
+	mock,
+} from "bun:test";
 import { existsSync } from "node:fs";
 import path from "node:path";
 import type { ApplicationNested } from "@dokploy/server";
 import { paths } from "@dokploy/server/constants";
+import * as adminServiceSrc from "@dokploy/server/services/admin";
+import * as applicationServiceSrc from "@dokploy/server/services/application";
+import * as deploymentServiceSrc from "@dokploy/server/services/deployment";
+import * as rollbacksServiceSrc from "@dokploy/server/services/rollbacks";
+import * as buildErrorSrc from "@dokploy/server/utils/notifications/build-error";
+import * as buildSuccessSrc from "@dokploy/server/utils/notifications/build-success";
 import { execAsync } from "@dokploy/server/utils/process/execAsync";
 import { format } from "date-fns";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDbMock } from "../db-mock";
+
+// Snapshot before mocking - `mock.module` has no `importActual`, and it is
+// process-global, so each stub is put back in `afterAll`.
+const actual = {
+	adminService: { ...adminServiceSrc },
+	applicationService: { ...applicationServiceSrc },
+	deploymentService: { ...deploymentServiceSrc },
+	rollbacksService: { ...rollbacksServiceSrc },
+	buildError: { ...buildErrorSrc },
+	buildSuccess: { ...buildSuccessSrc },
+};
+
+// Named handles: bun:test has no `vi.mocked`, and referencing these directly is
+// better typed than casting the namespace member at each call site.
+const findApplicationByIdMock = jest.fn();
+const updateApplicationStatusMock = jest.fn();
+const getDokployUrlMock = jest.fn().mockResolvedValue("http://localhost:3000");
+const createDeploymentMock = jest.fn();
+const updateDeploymentStatusMock = jest.fn();
+const updateDeploymentMock = jest.fn();
+const applicationsFindFirstMock = jest.fn();
 
 const REAL_TEST_TIMEOUT = 180000; // 3 minutes
 
 // Mock ONLY database and notifications
-vi.mock("@dokploy/server/db", () => {
+mock.module("@dokploy/server/db", () => {
 	const createChainableMock = (): any => {
 		const chain: any = {
-			set: vi.fn(() => chain),
-			where: vi.fn(() => chain),
-			returning: vi.fn().mockResolvedValue([{}]),
-			from: vi.fn(() => chain),
-			innerJoin: vi.fn(() => chain),
+			set: jest.fn(() => chain),
+			where: jest.fn(() => chain),
+			returning: jest.fn().mockResolvedValue([{}]),
+			from: jest.fn(() => chain),
+			innerJoin: jest.fn(() => chain),
 			then: (resolve: (v: any) => void) => {
 				resolve([]);
 			},
@@ -26,56 +63,56 @@ vi.mock("@dokploy/server/db", () => {
 
 	return {
 		db: {
-			select: vi.fn(() => createChainableMock()),
-			insert: vi.fn(),
-			update: vi.fn(() => createChainableMock()),
-			delete: vi.fn(),
+			select: jest.fn(() => createChainableMock()),
+			insert: jest.fn(),
+			update: jest.fn(() => createChainableMock()),
+			delete: jest.fn(),
 			query: {
 				applications: {
-					findFirst: vi.fn(),
+					findFirst: applicationsFindFirstMock,
 				},
 				patch: {
-					findMany: vi.fn().mockResolvedValue([]),
+					findMany: jest.fn().mockResolvedValue([]),
 				},
 				member: {
-					findMany: vi.fn().mockResolvedValue([]),
+					findMany: jest.fn().mockResolvedValue([]),
 				},
 			},
 		},
 	};
 });
 
-vi.mock("@dokploy/server/services/application", async () => {
-	const actual = await vi.importActual<
-		typeof import("@dokploy/server/services/application")
-	>("@dokploy/server/services/application");
-	return {
-		...actual,
-		findApplicationById: vi.fn(),
-		updateApplicationStatus: vi.fn(),
-	};
-});
-
-vi.mock("@dokploy/server/services/admin", () => ({
-	getDokployUrl: vi.fn().mockResolvedValue("http://localhost:3000"),
+mock.module("@dokploy/server/services/application", () => ({
+	...actual.applicationService,
+	findApplicationById: findApplicationByIdMock,
+	updateApplicationStatus: updateApplicationStatusMock,
 }));
 
-vi.mock("@dokploy/server/services/deployment", () => ({
-	createDeployment: vi.fn(),
-	updateDeploymentStatus: vi.fn(),
-	updateDeployment: vi.fn(),
+mock.module("@dokploy/server/services/admin", () => ({
+	...actual.adminService,
+	getDokployUrl: getDokployUrlMock,
 }));
 
-vi.mock("@dokploy/server/utils/notifications/build-success", () => ({
-	sendBuildSuccessNotifications: vi.fn(),
+mock.module("@dokploy/server/services/deployment", () => ({
+	...actual.deploymentService,
+	createDeployment: createDeploymentMock,
+	updateDeploymentStatus: updateDeploymentStatusMock,
+	updateDeployment: updateDeploymentMock,
 }));
 
-vi.mock("@dokploy/server/utils/notifications/build-error", () => ({
-	sendBuildErrorNotifications: vi.fn(),
+mock.module("@dokploy/server/utils/notifications/build-success", () => ({
+	...actual.buildSuccess,
+	sendBuildSuccessNotifications: jest.fn(),
 }));
 
-vi.mock("@dokploy/server/services/rollbacks", () => ({
-	createRollback: vi.fn(),
+mock.module("@dokploy/server/utils/notifications/build-error", () => ({
+	...actual.buildError,
+	sendBuildErrorNotifications: jest.fn(),
+}));
+
+mock.module("@dokploy/server/services/rollbacks", () => ({
+	...actual.rollbacksService,
+	createRollback: jest.fn(),
 }));
 
 // NOT mocked (executed for real):
@@ -171,320 +208,309 @@ async function cleanupFiles(appName: string) {
 	}
 }
 
-describe(
-	"deployApplication - REAL Execution Tests",
-	() => {
-		let currentAppName: string;
-		let currentDeployment: any;
-		const allTestAppNames: string[] = [];
+describe("deployApplication - REAL Execution Tests", () => {
+	let currentAppName: string;
+	let currentDeployment: any;
+	const allTestAppNames: string[] = [];
 
-		beforeEach(async () => {
-			vi.clearAllMocks();
-			currentAppName = `real-test-${Date.now()}`;
-			currentDeployment = await createMockDeployment(currentAppName);
-			allTestAppNames.push(currentAppName);
+	beforeEach(async () => {
+		jest.clearAllMocks();
+		currentAppName = `real-test-${Date.now()}`;
+		currentDeployment = await createMockDeployment(currentAppName);
+		allTestAppNames.push(currentAppName);
 
-			const mockApp = createMockApplication({ appName: currentAppName });
+		const mockApp = createMockApplication({ appName: currentAppName });
 
-			vi.mocked(db.query.applications.findFirst).mockResolvedValue(
-				mockApp as any,
+		applicationsFindFirstMock.mockResolvedValue(mockApp as any);
+		findApplicationByIdMock.mockResolvedValue(mockApp as any);
+		getDokployUrlMock.mockResolvedValue("http://localhost:3000");
+		createDeploymentMock.mockResolvedValue(currentDeployment as any);
+		updateDeploymentStatusMock.mockResolvedValue(undefined as any);
+		updateApplicationStatusMock.mockResolvedValue({} as any);
+		updateDeploymentMock.mockResolvedValue({} as any);
+	});
+
+	afterEach(async () => {
+		// ALWAYS cleanup, even if test failed or passed
+		console.log(`\n🧹 Cleaning up test: ${currentAppName}`);
+
+		// Clean current appName
+		try {
+			await cleanupDocker(currentAppName);
+			await cleanupFiles(currentAppName);
+		} catch (error) {
+			console.error("⚠️ Error cleaning current app:", error);
+		}
+
+		// Clean ALL test folders just in case
+		try {
+			const { LOGS_PATH, APPLICATIONS_PATH } = paths(false);
+			await execAsync(`rm -rf ${LOGS_PATH}/real-* 2>/dev/null || true`);
+			await execAsync(`rm -rf ${APPLICATIONS_PATH}/real-* 2>/dev/null || true`);
+			console.log("✅ Cleaned up all test artifacts");
+		} catch (error) {
+			console.error("⚠️ Error cleaning all artifacts:", error);
+		}
+
+		console.log("✅ Cleanup completed\n");
+	});
+
+	it(
+		"should REALLY clone git repo and build with nixpacks",
+		async () => {
+			console.log(`\n🚀 Testing real deployment with app: ${currentAppName}`);
+
+			const result = await deployApplication({
+				applicationId: "test-app-id",
+				titleLog: "Real Nixpacks Test",
+				descriptionLog: "Testing real execution",
+			});
+
+			expect(result).toBe(true);
+
+			// Verify that Docker image was actually created
+			const { stdout: dockerImages } = await execAsync(
+				`docker images ${currentAppName} --format "{{.Repository}}"`,
 			);
-			vi.mocked(applicationService.findApplicationById).mockResolvedValue(
-				mockApp as any,
-			);
-			vi.mocked(adminService.getDokployUrl).mockResolvedValue(
-				"http://localhost:3000",
-			);
-			vi.mocked(deploymentService.createDeployment).mockResolvedValue(
-				currentDeployment as any,
-			);
-			vi.mocked(deploymentService.updateDeploymentStatus).mockResolvedValue(
-				undefined as any,
-			);
-			vi.mocked(applicationService.updateApplicationStatus).mockResolvedValue(
-				{} as any,
-			);
-			vi.mocked(deploymentService.updateDeployment).mockResolvedValue(
-				{} as any,
-			);
-		});
+			console.log("dockerImages", dockerImages);
+			expect(dockerImages.trim()).toBe(currentAppName);
+			console.log(`✅ Docker image created: ${currentAppName}`);
 
-		afterEach(async () => {
-			// ALWAYS cleanup, even if test failed or passed
-			console.log(`\n🧹 Cleaning up test: ${currentAppName}`);
+			// Verify log exists and has content
+			expect(existsSync(currentDeployment.logPath)).toBe(true);
+			const { stdout: logContent } = await execAsync(
+				`cat ${currentDeployment.logPath}`,
+			);
+			expect(logContent).toContain("Cloning");
+			expect(logContent).toContain("nixpacks");
+			console.log(`✅ Build log created with ${logContent.length} chars`);
 
-			// Clean current appName
-			try {
-				await cleanupDocker(currentAppName);
-				await cleanupFiles(currentAppName);
-			} catch (error) {
-				console.error("⚠️ Error cleaning current app:", error);
-			}
+			// Verify update functions were called
+			expect(deploymentService.updateDeploymentStatus).toHaveBeenCalledWith(
+				"deployment-id",
+				"done",
+			);
+		},
+		REAL_TEST_TIMEOUT,
+	);
 
-			// Clean ALL test folders just in case
-			try {
-				const { LOGS_PATH, APPLICATIONS_PATH } = paths(false);
-				await execAsync(`rm -rf ${LOGS_PATH}/real-* 2>/dev/null || true`);
-				await execAsync(
-					`rm -rf ${APPLICATIONS_PATH}/real-* 2>/dev/null || true`,
-				);
-				console.log("✅ Cleaned up all test artifacts");
-			} catch (error) {
-				console.error("⚠️ Error cleaning all artifacts:", error);
-			}
+	it.skip(
+		"should REALLY build with railpack (SKIPPED: requires special permissions)",
+		async () => {
+			const railpackAppName = `real-railpack-${Date.now()}`;
+			const railpackApp = createMockApplication({
+				appName: railpackAppName,
+				buildType: "railpack",
+				railpackVersion: "3",
+			});
+			currentAppName = railpackAppName;
+			allTestAppNames.push(railpackAppName);
 
-			console.log("✅ Cleanup completed\n");
-		});
+			applicationsFindFirstMock.mockResolvedValue(railpackApp as any);
+			findApplicationByIdMock.mockResolvedValue(railpackApp as any);
 
-		it(
-			"should REALLY clone git repo and build with nixpacks",
-			async () => {
-				console.log(`\n🚀 Testing real deployment with app: ${currentAppName}`);
+			console.log(`\n🚀 Testing real railpack deployment: ${currentAppName}`);
 
-				const result = await deployApplication({
+			const result = await deployApplication({
+				applicationId: "test-app-id",
+				titleLog: "Real Railpack Test",
+				descriptionLog: "",
+			});
+
+			expect(result).toBe(true);
+
+			const { stdout: dockerImages } = await execAsync(
+				`docker images ${currentAppName} --format "{{.Repository}}"`,
+			);
+			expect(dockerImages.trim()).toBe(currentAppName);
+			console.log(`✅ Railpack image created: ${currentAppName}`);
+
+			const { stdout: logContent } = await execAsync(
+				`cat ${currentDeployment.logPath}`,
+			);
+			expect(logContent).toContain("railpack");
+			console.log("✅ Railpack build completed");
+		},
+		REAL_TEST_TIMEOUT,
+	);
+
+	it(
+		"should handle REAL git clone errors",
+		async () => {
+			const errorAppName = `real-error-${Date.now()}`;
+			const errorApp = createMockApplication({
+				appName: errorAppName,
+				customGitUrl: "https://github.com/invalid/nonexistent-repo-123456.git",
+			});
+			currentAppName = errorAppName;
+			allTestAppNames.push(errorAppName);
+
+			applicationsFindFirstMock.mockResolvedValue(errorApp as any);
+			findApplicationByIdMock.mockResolvedValue(errorApp as any);
+
+			console.log(`\n🚀 Testing real error handling: ${currentAppName}`);
+
+			await expect(
+				deployApplication({
 					applicationId: "test-app-id",
-					titleLog: "Real Nixpacks Test",
-					descriptionLog: "Testing real execution",
-				});
-
-				expect(result).toBe(true);
-
-				// Verify that Docker image was actually created
-				const { stdout: dockerImages } = await execAsync(
-					`docker images ${currentAppName} --format "{{.Repository}}"`,
-				);
-				console.log("dockerImages", dockerImages);
-				expect(dockerImages.trim()).toBe(currentAppName);
-				console.log(`✅ Docker image created: ${currentAppName}`);
-
-				// Verify log exists and has content
-				expect(existsSync(currentDeployment.logPath)).toBe(true);
-				const { stdout: logContent } = await execAsync(
-					`cat ${currentDeployment.logPath}`,
-				);
-				expect(logContent).toContain("Cloning");
-				expect(logContent).toContain("nixpacks");
-				console.log(`✅ Build log created with ${logContent.length} chars`);
-
-				// Verify update functions were called
-				expect(deploymentService.updateDeploymentStatus).toHaveBeenCalledWith(
-					"deployment-id",
-					"done",
-				);
-			},
-			REAL_TEST_TIMEOUT,
-		);
-
-		it.skip(
-			"should REALLY build with railpack (SKIPPED: requires special permissions)",
-			async () => {
-				const railpackAppName = `real-railpack-${Date.now()}`;
-				const railpackApp = createMockApplication({
-					appName: railpackAppName,
-					buildType: "railpack",
-					railpackVersion: "3",
-				});
-				currentAppName = railpackAppName;
-				allTestAppNames.push(railpackAppName);
-
-				vi.mocked(db.query.applications.findFirst).mockResolvedValue(
-					railpackApp as any,
-				);
-				vi.mocked(applicationService.findApplicationById).mockResolvedValue(
-					railpackApp as any,
-				);
-
-				console.log(`\n🚀 Testing real railpack deployment: ${currentAppName}`);
-
-				const result = await deployApplication({
-					applicationId: "test-app-id",
-					titleLog: "Real Railpack Test",
+					titleLog: "Real Error Test",
 					descriptionLog: "",
-				});
+				}),
+			).rejects.toThrow();
 
-				expect(result).toBe(true);
+			// Verify error status was called
+			expect(deploymentService.updateDeploymentStatus).toHaveBeenCalledWith(
+				"deployment-id",
+				"error",
+			);
 
-				const { stdout: dockerImages } = await execAsync(
-					`docker images ${currentAppName} --format "{{.Repository}}"`,
-				);
-				expect(dockerImages.trim()).toBe(currentAppName);
-				console.log(`✅ Railpack image created: ${currentAppName}`);
+			// Verify log contains error
+			const { stdout: logContent } = await execAsync(
+				`cat ${currentDeployment.logPath}`,
+			);
+			expect(logContent.toLowerCase()).toContain("error");
+			console.log("✅ Error handling verified");
+		},
+		REAL_TEST_TIMEOUT,
+	);
 
-				const { stdout: logContent } = await execAsync(
-					`cat ${currentDeployment.logPath}`,
-				);
-				expect(logContent).toContain("railpack");
-				console.log("✅ Railpack build completed");
-			},
-			REAL_TEST_TIMEOUT,
-		);
+	it(
+		"should REALLY clone with submodules when enabled",
+		async () => {
+			const submodulesAppName = `real-submodules-${Date.now()}`;
+			const submodulesApp = createMockApplication({
+				appName: submodulesAppName,
+				enableSubmodules: true,
+			});
+			currentAppName = submodulesAppName;
+			allTestAppNames.push(submodulesAppName);
 
-		it(
-			"should handle REAL git clone errors",
-			async () => {
-				const errorAppName = `real-error-${Date.now()}`;
-				const errorApp = createMockApplication({
-					appName: errorAppName,
-					customGitUrl:
-						"https://github.com/invalid/nonexistent-repo-123456.git",
-				});
-				currentAppName = errorAppName;
-				allTestAppNames.push(errorAppName);
+			applicationsFindFirstMock.mockResolvedValue(submodulesApp as any);
+			findApplicationByIdMock.mockResolvedValue(submodulesApp as any);
 
-				vi.mocked(db.query.applications.findFirst).mockResolvedValue(
-					errorApp as any,
-				);
-				vi.mocked(applicationService.findApplicationById).mockResolvedValue(
-					errorApp as any,
-				);
+			console.log(`\n🚀 Testing real submodules support: ${currentAppName}`);
 
-				console.log(`\n🚀 Testing real error handling: ${currentAppName}`);
+			const result = await deployApplication({
+				applicationId: "test-app-id",
+				titleLog: "Real Submodules Test",
+				descriptionLog: "",
+			});
 
-				await expect(
-					deployApplication({
-						applicationId: "test-app-id",
-						titleLog: "Real Error Test",
-						descriptionLog: "",
-					}),
-				).rejects.toThrow();
+			expect(result).toBe(true);
 
-				// Verify error status was called
-				expect(deploymentService.updateDeploymentStatus).toHaveBeenCalledWith(
-					"deployment-id",
-					"error",
-				);
+			// Verify deployment completed successfully
+			const { stdout: logContent } = await execAsync(
+				`cat ${currentDeployment.logPath}`,
+			);
+			expect(logContent).toContain("Cloning");
+			expect(logContent.length).toBeGreaterThan(100);
+			console.log("✅ Submodules deployment completed");
 
-				// Verify log contains error
-				const { stdout: logContent } = await execAsync(
-					`cat ${currentDeployment.logPath}`,
-				);
-				expect(logContent.toLowerCase()).toContain("error");
-				console.log("✅ Error handling verified");
-			},
-			REAL_TEST_TIMEOUT,
-		);
+			// Verify image
+			const { stdout: dockerImages } = await execAsync(
+				`docker images ${currentAppName} --format "{{.Repository}}"`,
+			);
+			expect(dockerImages.trim()).toBe(currentAppName);
+		},
+		REAL_TEST_TIMEOUT,
+	);
 
-		it(
-			"should REALLY clone with submodules when enabled",
-			async () => {
-				const submodulesAppName = `real-submodules-${Date.now()}`;
-				const submodulesApp = createMockApplication({
-					appName: submodulesAppName,
-					enableSubmodules: true,
-				});
-				currentAppName = submodulesAppName;
-				allTestAppNames.push(submodulesAppName);
+	it(
+		"should verify REAL commit info extraction",
+		async () => {
+			console.log(`\n🚀 Testing real commit info: ${currentAppName}`);
 
-				vi.mocked(db.query.applications.findFirst).mockResolvedValue(
-					submodulesApp as any,
-				);
-				vi.mocked(applicationService.findApplicationById).mockResolvedValue(
-					submodulesApp as any,
-				);
+			await deployApplication({
+				applicationId: "test-app-id",
+				titleLog: "Real Commit Test",
+				descriptionLog: "",
+			});
 
-				console.log(`\n🚀 Testing real submodules support: ${currentAppName}`);
+			// Verify updateDeployment was called with commit info
+			expect(deploymentService.updateDeployment).toHaveBeenCalled();
+			const updateCall = updateDeploymentMock.mock.calls[0];
 
-				const result = await deployApplication({
-					applicationId: "test-app-id",
-					titleLog: "Real Submodules Test",
-					descriptionLog: "",
-				});
+			// Real commit info should have title and hash
+			expect(updateCall?.[1]).toHaveProperty("title");
+			expect(updateCall?.[1]).toHaveProperty("description");
+			expect(updateCall?.[1]?.description).toContain("Commit:");
 
-				expect(result).toBe(true);
+			console.log(
+				`✅ Real commit extracted: ${updateCall?.[1]?.title?.substring(0, 50)}...`,
+			);
+		},
+		REAL_TEST_TIMEOUT,
+	);
 
-				// Verify deployment completed successfully
-				const { stdout: logContent } = await execAsync(
-					`cat ${currentDeployment.logPath}`,
-				);
-				expect(logContent).toContain("Cloning");
-				expect(logContent.length).toBeGreaterThan(100);
-				console.log("✅ Submodules deployment completed");
+	it(
+		"should REALLY build with Dockerfile",
+		async () => {
+			const dockerfileAppName = `real-dockerfile-${Date.now()}`;
+			const dockerfileApp = createMockApplication({
+				appName: dockerfileAppName,
+				buildType: "dockerfile",
+				customGitBuildPath: "/deno",
+				dockerfile: "Dockerfile",
+			});
+			currentAppName = dockerfileAppName;
+			allTestAppNames.push(dockerfileAppName);
 
-				// Verify image
-				const { stdout: dockerImages } = await execAsync(
-					`docker images ${currentAppName} --format "{{.Repository}}"`,
-				);
-				expect(dockerImages.trim()).toBe(currentAppName);
-			},
-			REAL_TEST_TIMEOUT,
-		);
+			applicationsFindFirstMock.mockResolvedValue(dockerfileApp as any);
+			findApplicationByIdMock.mockResolvedValue(dockerfileApp as any);
 
-		it(
-			"should verify REAL commit info extraction",
-			async () => {
-				console.log(`\n🚀 Testing real commit info: ${currentAppName}`);
+			console.log(`\n🚀 Testing real Dockerfile build: ${currentAppName}`);
 
-				await deployApplication({
-					applicationId: "test-app-id",
-					titleLog: "Real Commit Test",
-					descriptionLog: "",
-				});
+			const result = await deployApplication({
+				applicationId: "test-app-id",
+				titleLog: "Real Dockerfile Test",
+				descriptionLog: "",
+			});
 
-				// Verify updateDeployment was called with commit info
-				expect(deploymentService.updateDeployment).toHaveBeenCalled();
-				const updateCall = vi.mocked(deploymentService.updateDeployment).mock
-					.calls[0];
+			expect(result).toBe(true);
 
-				// Real commit info should have title and hash
-				expect(updateCall?.[1]).toHaveProperty("title");
-				expect(updateCall?.[1]).toHaveProperty("description");
-				expect(updateCall?.[1]?.description).toContain("Commit:");
+			// Verify log
+			const { stdout: logContent } = await execAsync(
+				`cat ${currentDeployment.logPath}`,
+			);
+			expect(logContent).toContain("Building");
+			expect(logContent).toContain(dockerfileAppName);
+			console.log("✅ Dockerfile build log verified");
 
-				console.log(
-					`✅ Real commit extracted: ${updateCall?.[1]?.title?.substring(0, 50)}...`,
-				);
-			},
-			REAL_TEST_TIMEOUT,
-		);
+			// Verify image
+			const { stdout: dockerImages } = await execAsync(
+				`docker images ${currentAppName} --format "{{.Repository}}"`,
+			);
+			console.log("dockerImages", dockerImages);
+			expect(dockerImages.trim()).toBe(currentAppName);
+			console.log(`✅ Docker image created: ${currentAppName}`);
+		},
+		REAL_TEST_TIMEOUT,
+	);
+});
+// bun:test's `describe` takes no timeout argument; every `it` below already
+// carries REAL_TEST_TIMEOUT of its own, so nothing is lost.
 
-		it(
-			"should REALLY build with Dockerfile",
-			async () => {
-				const dockerfileAppName = `real-dockerfile-${Date.now()}`;
-				const dockerfileApp = createMockApplication({
-					appName: dockerfileAppName,
-					buildType: "dockerfile",
-					customGitBuildPath: "/deno",
-					dockerfile: "Dockerfile",
-				});
-				currentAppName = dockerfileAppName;
-				allTestAppNames.push(dockerfileAppName);
-
-				vi.mocked(db.query.applications.findFirst).mockResolvedValue(
-					dockerfileApp as any,
-				);
-				vi.mocked(applicationService.findApplicationById).mockResolvedValue(
-					dockerfileApp as any,
-				);
-
-				console.log(`\n🚀 Testing real Dockerfile build: ${currentAppName}`);
-
-				const result = await deployApplication({
-					applicationId: "test-app-id",
-					titleLog: "Real Dockerfile Test",
-					descriptionLog: "",
-				});
-
-				expect(result).toBe(true);
-
-				// Verify log
-				const { stdout: logContent } = await execAsync(
-					`cat ${currentDeployment.logPath}`,
-				);
-				expect(logContent).toContain("Building");
-				expect(logContent).toContain(dockerfileAppName);
-				console.log("✅ Dockerfile build log verified");
-
-				// Verify image
-				const { stdout: dockerImages } = await execAsync(
-					`docker images ${currentAppName} --format "{{.Repository}}"`,
-				);
-				console.log("dockerImages", dockerImages);
-				expect(dockerImages.trim()).toBe(currentAppName);
-				console.log(`✅ Docker image created: ${currentAppName}`);
-			},
-			REAL_TEST_TIMEOUT,
-		);
-	},
-	REAL_TEST_TIMEOUT,
-);
+afterAll(() => {
+	mock.module("@dokploy/server/db", () => createDbMock(jest.fn));
+	mock.module("@dokploy/server/services/admin", () => actual.adminService);
+	mock.module(
+		"@dokploy/server/services/application",
+		() => actual.applicationService,
+	);
+	mock.module(
+		"@dokploy/server/services/deployment",
+		() => actual.deploymentService,
+	);
+	mock.module(
+		"@dokploy/server/services/rollbacks",
+		() => actual.rollbacksService,
+	);
+	mock.module(
+		"@dokploy/server/utils/notifications/build-error",
+		() => actual.buildError,
+	);
+	mock.module(
+		"@dokploy/server/utils/notifications/build-success",
+		() => actual.buildSuccess,
+	);
+});

--- a/apps/dokploy/__test__/deploy/db-service-dockerimage-injection.test.ts
+++ b/apps/dokploy/__test__/deploy/db-service-dockerimage-injection.test.ts
@@ -1,7 +1,7 @@
+import { describe, expect, it } from "bun:test";
 import { execSync } from "node:child_process";
 import { existsSync, rmSync } from "node:fs";
 import { parse, quote } from "shell-quote";
-import { describe, expect, it } from "vitest";
 
 // The six database deploy functions (postgres/mysql/mariadb/mongo/redis/libsql)
 // build `docker pull ${quote([dockerImage])}` for the remote (execAsyncRemote)

--- a/apps/dokploy/__test__/deploy/docker-build-injection.test.ts
+++ b/apps/dokploy/__test__/deploy/docker-build-injection.test.ts
@@ -1,7 +1,7 @@
+import { describe, expect, it } from "bun:test";
 import { execSync } from "node:child_process";
 import { existsSync, rmSync } from "node:fs";
 import { parse, quote } from "shell-quote";
-import { describe, expect, it } from "vitest";
 
 // Reproduces the escaping applied at the docker build/pull sinks and asserts no
 // payload can break out of the command. `docker`/`cd` are replaced by `:` so the

--- a/apps/dokploy/__test__/deploy/env-file-literals-dockerfile.test.ts
+++ b/apps/dokploy/__test__/deploy/env-file-literals-dockerfile.test.ts
@@ -1,9 +1,9 @@
+import { afterEach, describe, expect, it } from "bun:test";
 import { execFileSync } from "node:child_process";
 import { mkdirSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { createEnvFileCommand } from "@dokploy/server/utils/builders/utils";
 import { parse } from "dotenv";
-import { afterEach, describe, expect, it } from "vitest";
 
 // Unlike compose's .env, this one is read by the app's own build tooling
 // (generic dotenv, e.g. Next.js/Vite) — must stay unquoted, not Compose-escaped.

--- a/apps/dokploy/__test__/deploy/github-webhook-handler.test.ts
+++ b/apps/dokploy/__test__/deploy/github-webhook-handler.test.ts
@@ -1,25 +1,54 @@
+import {
+	afterAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	jest,
+	mock,
+} from "bun:test";
+import * as serverBarrel from "@dokploy/server";
+import * as octokitWebhooks from "@octokit/webhooks";
+import * as drizzleOrm from "drizzle-orm";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as dbSchema from "@/server/db/schema";
+import * as queueSetup from "@/server/queues/queueSetup";
+import * as deployUtil from "@/server/utils/deploy";
+import { createDbMock } from "../db-mock";
 
-const mocks = vi.hoisted(() => ({
-	eq: vi.fn((field: string, value: unknown) => ({ field, value })),
-	and: vi.fn((...conditions: Array<{ field: string; value: unknown }>) => ({
+// Snapshot every module before replacing it. `mock.module` is process-global
+// and `mock.restore()` does not undo it, so a narrow stub of `drizzle-orm` or
+// the `@dokploy/server` barrel would change every later file in the run.
+const actual = {
+	drizzleOrm: { ...drizzleOrm },
+	dbSchema: { ...dbSchema },
+	serverBarrel: { ...serverBarrel },
+	octokitWebhooks: { ...octokitWebhooks },
+	queueSetup: { ...queueSetup },
+	deployUtil: { ...deployUtil },
+};
+
+const mocks = {
+	eq: jest.fn((field: string, value: unknown) => ({ field, value })),
+	and: jest.fn((...conditions: Array<{ field: string; value: unknown }>) => ({
 		conditions,
 	})),
-	githubFindFirst: vi.fn(),
-	applicationsFindMany: vi.fn(),
-	composeFindMany: vi.fn(),
-	queueAdd: vi.fn(),
-	verify: vi.fn(),
-	shouldDeploy: vi.fn(),
-}));
+	githubFindFirst: jest.fn(),
+	applicationsFindMany: jest.fn(),
+	composeFindMany: jest.fn(),
+	queueAdd: jest.fn(),
+	verify: jest.fn(),
+	shouldDeploy: jest.fn(),
+};
 
-vi.mock("drizzle-orm", () => ({
+mock.module("drizzle-orm", () => ({
+	...actual.drizzleOrm,
 	eq: mocks.eq,
 	and: mocks.and,
 }));
 
-vi.mock("@/server/db/schema", () => ({
+mock.module("@/server/db/schema", () => ({
+	...actual.dbSchema,
 	applications: {
 		sourceType: "application.sourceType",
 		autoDeploy: "application.autoDeploy",
@@ -44,7 +73,7 @@ vi.mock("@/server/db/schema", () => ({
 	},
 }));
 
-vi.mock("@dokploy/server/db", () => ({
+mock.module("@dokploy/server/db", () => ({
 	db: {
 		query: {
 			github: {
@@ -60,38 +89,52 @@ vi.mock("@dokploy/server/db", () => ({
 	},
 }));
 
-vi.mock("@dokploy/server", () => ({
+mock.module("@dokploy/server", () => ({
+	...actual.serverBarrel,
 	IS_CLOUD: false,
 	shouldDeploy: mocks.shouldDeploy,
-	checkUserRepositoryPermissions: vi.fn(),
-	createPreviewDeployment: vi.fn(),
-	createSecurityBlockedComment: vi.fn(),
-	findGithubById: vi.fn(),
-	findPreviewDeploymentByApplicationId: vi.fn(),
-	findPreviewDeploymentsByPullRequestId: vi.fn(),
-	getBitbucketHeaders: vi.fn(() => ({})),
-	removePreviewDeployment: vi.fn(),
+	checkUserRepositoryPermissions: jest.fn(),
+	createPreviewDeployment: jest.fn(),
+	createSecurityBlockedComment: jest.fn(),
+	findGithubById: jest.fn(),
+	findPreviewDeploymentByApplicationId: jest.fn(),
+	findPreviewDeploymentsByPullRequestId: jest.fn(),
+	getBitbucketHeaders: jest.fn(() => ({})),
+	removePreviewDeployment: jest.fn(),
 }));
 
-vi.mock("@octokit/webhooks", () => ({
-	Webhooks: vi.fn().mockImplementation(function Webhooks() {
+mock.module("@octokit/webhooks", () => ({
+	...actual.octokitWebhooks,
+	Webhooks: jest.fn().mockImplementation(function Webhooks() {
 		return {
 			verify: mocks.verify,
 		};
 	}),
 }));
 
-vi.mock("@/server/queues/queueSetup", () => ({
+mock.module("@/server/queues/queueSetup", () => ({
+	...actual.queueSetup,
 	myQueue: {
 		add: mocks.queueAdd,
 	},
 }));
 
-vi.mock("@/server/utils/deploy", () => ({
-	deploy: vi.fn(),
+mock.module("@/server/utils/deploy", () => ({
+	...actual.deployUtil,
+	deploy: jest.fn(),
 }));
 
-import handler from "@/pages/api/deploy/github";
+const { default: handler } = await import("@/pages/api/deploy/github");
+
+afterAll(() => {
+	mock.module("drizzle-orm", () => actual.drizzleOrm);
+	mock.module("@/server/db/schema", () => actual.dbSchema);
+	mock.module("@dokploy/server", () => actual.serverBarrel);
+	mock.module("@octokit/webhooks", () => actual.octokitWebhooks);
+	mock.module("@/server/queues/queueSetup", () => actual.queueSetup);
+	mock.module("@/server/utils/deploy", () => actual.deployUtil);
+	mock.module("@dokploy/server/db", () => createDbMock(jest.fn));
+});
 
 const getConditionValue = (
 	where: { conditions?: Array<{ field: string; value: unknown }> } | undefined,
@@ -100,11 +143,11 @@ const getConditionValue = (
 
 const createResponse = () => {
 	const res = {
-		status: vi.fn(),
-		json: vi.fn(),
+		status: jest.fn(),
+		json: jest.fn(),
 	} as unknown as NextApiResponse & {
-		status: ReturnType<typeof vi.fn>;
-		json: ReturnType<typeof vi.fn>;
+		status: ReturnType<typeof jest.fn>;
+		json: ReturnType<typeof jest.fn>;
 	};
 
 	res.status.mockImplementation(() => res);
@@ -159,7 +202,7 @@ const createTagRequest = (tagName: string) => {
 
 describe("GitHub app webhook auto-deploy", () => {
 	beforeEach(() => {
-		vi.clearAllMocks();
+		jest.clearAllMocks();
 		mocks.githubFindFirst.mockResolvedValue({
 			githubId: "github-provider-id",
 			githubInstallationId: 12345,

--- a/apps/dokploy/__test__/deploy/github.test.ts
+++ b/apps/dokploy/__test__/deploy/github.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "bun:test";
 import {
 	extractCommitMessage,
 	extractImageName,

--- a/apps/dokploy/__test__/deploy/railpack.command.test.ts
+++ b/apps/dokploy/__test__/deploy/railpack.command.test.ts
@@ -1,6 +1,6 @@
+import { describe, expect, it } from "bun:test";
 import type { ApplicationNested } from "@dokploy/server/utils/builders";
 import { getRailpackCommand } from "@dokploy/server/utils/builders/railpack";
-import { describe, expect, it } from "vitest";
 
 const createApplication = (
 	overrides: Partial<ApplicationNested> = {},

--- a/apps/dokploy/__test__/deploy/should-deploy.test.ts
+++ b/apps/dokploy/__test__/deploy/should-deploy.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, it } from "bun:test";
 import { shouldDeploy } from "@dokploy/server";
-import { describe, expect, it } from "vitest";
 
 describe("shouldDeploy", () => {
 	it("should deploy when no watch paths are configured", () => {

--- a/apps/dokploy/__test__/deploy/soft-serve.test.ts
+++ b/apps/dokploy/__test__/deploy/soft-serve.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "bun:test";
 import {
 	extractBranchName,
 	extractCommitMessage,

--- a/apps/dokploy/__test__/drop/drop.test.ts
+++ b/apps/dokploy/__test__/drop/drop.test.ts
@@ -24,6 +24,14 @@ mock.module("@dokploy/server/constants", () => ({
 
 const { APPLICATIONS_PATH } = constants.paths();
 
+// `mock.module` is process-global, so this redirected `paths()` for every later
+// file in the run - which sent the deploy suite's real builds into
+// __test__/drop/zips/output. vitest never needed this: `pool: "forks"` gave each
+// file its own registry.
+afterAll(() => {
+	mock.module("@dokploy/server/constants", () => actual);
+});
+
 if (typeof window === "undefined") {
 	const undici = require("undici");
 	globalThis.File = undici.File as any;

--- a/apps/dokploy/__test__/vitest.config.ts
+++ b/apps/dokploy/__test__/vitest.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
 			"**/__test__/dns/**",
 			"**/__test__/compose/**",
 			"**/__test__/git-provider/**",
+			"**/__test__/deploy/**",
 		],
 		pool: "forks",
 		setupFiles: [path.resolve(__dirname, "setup.ts")],

--- a/apps/dokploy/__test__/wss/readValidDirectory.test.ts
+++ b/apps/dokploy/__test__/wss/readValidDirectory.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, mock } from "bun:test";
+import { afterAll, describe, expect, it, mock } from "bun:test";
 import path from "node:path";
 import * as constants from "@dokploy/server/constants";
 
@@ -20,6 +20,12 @@ mock.module("@dokploy/server/constants", () => ({
 
 // Import after mock so paths() uses our BASE
 const { readValidDirectory } = await import("@dokploy/server");
+
+// Same reason as drop.test.ts: put the real `paths()` back so this file's BASE
+// does not follow the rest of the run.
+afterAll(() => {
+	mock.module("@dokploy/server/constants", () => actual);
+});
 
 describe("readValidDirectory (path traversal)", () => {
 	it("returns true when directory is exactly BASE_PATH", () => {

--- a/apps/dokploy/package.json
+++ b/apps/dokploy/package.json
@@ -37,7 +37,7 @@
 		"docker:push:canary": "./docker/push.sh canary",
 		"version": "echo $(node -p \"require('./package.json').version\")",
 		"test": "bun run test:bun && bun run test:vitest",
-		"test:bun": "bun test __test__/logs __test__/registry __test__/requests __test__/api __test__/cluster __test__/templates __test__/backups __test__/services __test__/utils __test__/queues __test__/drop __test__/traefik __test__/server __test__/permissions __test__/wss __test__/dns __test__/compose __test__/git-provider",
+		"test:bun": "bun test __test__/logs __test__/registry __test__/requests __test__/api __test__/cluster __test__/templates __test__/backups __test__/services __test__/utils __test__/queues __test__/drop __test__/traefik __test__/server __test__/permissions __test__/wss __test__/dns __test__/compose __test__/git-provider __test__/deploy",
 		"test:vitest": "vitest --config __test__/vitest.config.ts",
 		"generate:openapi": "bun scripts/generate-openapi.ts"
 	},


### PR DESCRIPTION
The last portable directory. `bun test` goes **79 → 89 files, 680 → 749 tests**. vitest is left with `env` alone.

Seven files were a plain rename. The work was in three.

## `github-webhook-handler.test.ts`

Replaced `drizzle-orm`, `@/server/db/schema` and the **whole `@dokploy/server` barrel** with narrow objects and no spread. Under bun that strips those modules' other exports for every later file in the run — the widest version of the leak that broke #29. Each stub now spreads the original and is restored in `afterAll`.

## The two `application.*` files

Two things vitest has and bun does not:

- **`vi.importActual`** → namespace snapshots taken before mocking.
- **`vi.mocked`**, 35 call sites → there is no `jest.mocked` in bun:test (checked, it is `undefined`). Rather than casting at each call site, the mocks are now **named handles** used both in the factory and in the assertions:

```diff
-vi.mocked(applicationService.findApplicationById).mockResolvedValue(app);
+findApplicationByIdMock.mockResolvedValue(app);
```

Better typed than either the cast or the original, and no `@ts-ignore` anywhere.

`application.real.test.ts` also passed a timeout as `describe`'s **third argument** — vitest accepts it, bun does not. Dropped, and nothing is lost: all six `it` calls inside already carry `REAL_TEST_TIMEOUT` themselves.

## Verification

Swarm was temporarily initialised on the host for this and torn down afterwards (`docker swarm leave --force`; host confirmed back to `inactive`).

| Check | Result |
|---|---|
| Whole suite with **`deploy` first**, so its barrel/db stubs would hit everything else | 570 pass, no new failures |
| Each of the 10 files individually | no new failures |
| Sabotage of `shouldDeploy` | 3 extra failures ✅ |
| Pre-port vitest vs post-port bun test, swarm active | **exactly the same 3 failures, by name** |

Those 3 need `nixpacks` and `railpack`, which CI installs and this machine does not have. A 4th test needed only swarm and passes as soon as swarm is up — which is why it was worth initialising rather than assuming.

### One check produced no result, recorded rather than dressed up

Sabotaging `mechanizeDockerContainer` changed nothing, because the tests that exercise it are already failing on the missing build tools. **That path is verified by CI or not at all** — I am not claiming otherwise.

## Note on where failures now appear

`bun run test` behaves the same overall, but the half that fails on a machine without swarm/nixpacks has moved: vitest is now fully green locally (7 files, 121 tests), and those 3 failures show up under `bun test` instead.