### PR TITLE
feat: publish a version tag so the update panel can show one

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -82,6 +82,9 @@ jobs:
       matrix:
         suffix: ["", "-api", "-schedules"]
     steps:
+      # Needed only so the version-tag step below can read package.json.
+      - uses: actions/checkout@v4
+
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
@@ -100,3 +103,24 @@ jobs:
             "${image}:${tag}-amd64" \
             "${image}:${tag}-arm64"
           echo "Published ${image}:${tag} (amd64 + arm64)"
+
+          # The in-app update check only ever reports a version number when the
+          # running image is `latest` AND the registry holds a `v*` tag on the
+          # same digest - see getUpdateData in packages/server/src/services/
+          # settings.ts. Without this step it falls back to showing no version
+          # at all, which is why the panel used to read "canary".
+          if [ "$tag" = "latest" ]; then
+            version="$(grep -m1 '"version"' apps/dokploy/package.json | cut -d'"' -f4)"
+            if [ -z "$version" ]; then
+              echo "Could not read version from apps/dokploy/package.json" >&2
+              exit 1
+            fi
+            case "$version" in
+              v*) ;;
+              *) version="v${version}" ;;
+            esac
+            docker buildx imagetools create -t "${image}:${version}" \
+              "${image}:${tag}-amd64" \
+              "${image}:${tag}-arm64"
+            echo "Published ${image}:${version} (amd64 + arm64)"
+          fi


### PR DESCRIPTION
The update button reads **"New version available: canary"** instead of a version number, and redeploying never changes it. That is not a display bug — it is working as written.

## Why

`getUpdateData` ([settings.ts:126](packages/server/src/services/settings.ts:126)) has two paths:

```ts
if (currentImageTag === "canary" || currentImageTag === "feature") {
	// tags that move → compare digests
	return { latestVersion: currentImageTag, ... };   // ← literally "canary"
}
// stable path: find a v* tag whose digest matches `latest`, then semver
```

So a version number needs **two** things at once: the running image tagged `latest`, **and** a `v*` tag in the registry on the same digest.

`publish-images.yml` only ever pushed `latest`, `canary` and the commit SHA. The second condition could never be met — so even on `latest` the stable path fell through to `DEFAULT_UPDATE_DATA` and showed nothing at all.

## The change

The manifest job now also tags the `latest` manifest with the version from `apps/dokploy/package.json`.

It gained an `actions/checkout` for that — **it had none**, so without it the step would have read a missing file and cheerfully published an image tagged `v`. There is an explicit guard for that rather than a silent fallback:

```bash
if [ -z "$version" ]; then
  echo "Could not read version from apps/dokploy/package.json" >&2
  exit 1
fi
```

## Verified

The version survives the round trip through `semver`, which the comparison depends on:

| | |
|---|---|
| `semver.clean("v0.30.0-bun.1")` | `0.30.0-bun.1` |
| valid | ✅ |
| `v0.30.0-bun.2` > `v0.30.0-bun.1` | ✅ — bumping the suffix registers as an update |

YAML parses; the version extraction was run against the real `package.json` and produces `v0.30.0-bun.1` with no doubled `v`.

## This alone will not change your panel

Worth being explicit: merging this does nothing visible on its own. To actually see a version you need to

1. release on `main`, so `latest` + `v0.30.0-bun.1` get published, and
2. redeploy onto `:latest`.

**`:canary` will keep reporting "canary" by design** — that branch is a moving target and semver genuinely says nothing about it. Switching your instance from the canary channel to stable is a separate decision, not something this PR makes for you.