### PR TITLE
upstream: merge Dokploy canary (changePassword container lookup fix)

### DIFF
--- a/apps/dokploy/server/api/routers/mariadb.ts
+++ b/apps/dokploy/server/api/routers/mariadb.ts
@@ -11,7 +11,7 @@ import {
 	findProjectById,
 	getAccessibleServerIds,
 	getContainerLogs,
-	getServiceContainerCommand,
+	getServiceContainer,
 	getWebServerSettings,
 	IS_CLOUD,
 	rebuildDatabase,
@@ -410,17 +410,17 @@ export const mariadbRouter = createTRPCRouter({
 			const maria = await findMariadbById(mariadbId);
 			const { appName, serverId, databaseUser, databaseRootPassword } = maria;
 
-			const containerCmd = getServiceContainerCommand(appName);
+			const container = await getServiceContainer(appName, serverId);
+			if (!container) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: `No running container found for ${appName}`,
+				});
+			}
+
 			const targetUser = type === "root" ? "root" : databaseUser;
 
-			const command = `
-				CONTAINER_ID=$(${containerCmd})
-				if [ -z "$CONTAINER_ID" ]; then
-					echo "No running container found for ${appName}" >&2
-					exit 1
-				fi
-				docker exec "$CONTAINER_ID" mariadb -u root -p'${databaseRootPassword}' -e "ALTER USER '${targetUser}'@'%' IDENTIFIED BY '${password}'; FLUSH PRIVILEGES;"
-			`;
+			const command = `docker exec ${container.Id} mariadb -u root -p'${databaseRootPassword}' -e "ALTER USER '${targetUser}'@'%' IDENTIFIED BY '${password}'; FLUSH PRIVILEGES;"`;
 
 			await db.transaction(async (tx) => {
 				const setData =

--- a/apps/dokploy/server/api/routers/mongo.ts
+++ b/apps/dokploy/server/api/routers/mongo.ts
@@ -11,7 +11,7 @@ import {
 	findProjectById,
 	getAccessibleServerIds,
 	getContainerLogs,
-	getServiceContainerCommand,
+	getServiceContainer,
 	getWebServerSettings,
 	IS_CLOUD,
 	rebuildDatabase,
@@ -431,15 +431,15 @@ export const mongoRouter = createTRPCRouter({
 			const mongo = await findMongoById(mongoId);
 			const { appName, serverId, databaseUser, databasePassword } = mongo;
 
-			const containerCmd = getServiceContainerCommand(appName);
-			const command = `
-				CONTAINER_ID=$(${containerCmd})
-				if [ -z "$CONTAINER_ID" ]; then
-					echo "No running container found for ${appName}" >&2
-					exit 1
-				fi
-				docker exec "$CONTAINER_ID" mongosh -u '${databaseUser}' -p '${databasePassword}' --authenticationDatabase admin --eval "db.getSiblingDB('admin').changeUserPassword('${databaseUser}', '${password}')"
-			`;
+			const container = await getServiceContainer(appName, serverId);
+			if (!container) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: `No running container found for ${appName}`,
+				});
+			}
+
+			const command = `docker exec ${container.Id} mongosh -u '${databaseUser}' -p '${databasePassword}' --authenticationDatabase admin --eval "db.getSiblingDB('admin').changeUserPassword('${databaseUser}', '${password}')"`;
 
 			await db.transaction(async (tx) => {
 				await tx

--- a/apps/dokploy/server/api/routers/mysql.ts
+++ b/apps/dokploy/server/api/routers/mysql.ts
@@ -11,7 +11,7 @@ import {
 	findProjectById,
 	getAccessibleServerIds,
 	getContainerLogs,
-	getServiceContainerCommand,
+	getServiceContainer,
 	getWebServerSettings,
 	IS_CLOUD,
 	rebuildDatabase,
@@ -428,17 +428,17 @@ export const mysqlRouter = createTRPCRouter({
 			const my = await findMySqlById(mysqlId);
 			const { appName, serverId, databaseUser, databaseRootPassword } = my;
 
-			const containerCmd = getServiceContainerCommand(appName);
+			const container = await getServiceContainer(appName, serverId);
+			if (!container) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: `No running container found for ${appName}`,
+				});
+			}
+
 			const targetUser = type === "root" ? "root" : databaseUser;
 
-			const command = `
-				CONTAINER_ID=$(${containerCmd})
-				if [ -z "$CONTAINER_ID" ]; then
-					echo "No running container found for ${appName}" >&2
-					exit 1
-				fi
-				docker exec "$CONTAINER_ID" mysql -u root -p'${databaseRootPassword}' -e "ALTER USER '${targetUser}'@'%' IDENTIFIED BY '${password}'; FLUSH PRIVILEGES;"
-			`;
+			const command = `docker exec ${container.Id} mysql -u root -p'${databaseRootPassword}' -e "ALTER USER '${targetUser}'@'%' IDENTIFIED BY '${password}'; FLUSH PRIVILEGES;"`;
 
 			await db.transaction(async (tx) => {
 				const setData =

--- a/apps/dokploy/server/api/routers/postgres.ts
+++ b/apps/dokploy/server/api/routers/postgres.ts
@@ -12,7 +12,7 @@ import {
 	getAccessibleServerIds,
 	getContainerLogs,
 	getMountPath,
-	getServiceContainerCommand,
+	getServiceContainer,
 	getWebServerSettings,
 	IS_CLOUD,
 	rebuildDatabase,
@@ -437,15 +437,15 @@ export const postgresRouter = createTRPCRouter({
 			const pg = await findPostgresById(postgresId);
 			const { appName, serverId, databaseUser } = pg;
 
-			const containerCmd = getServiceContainerCommand(appName);
-			const command = `
-				CONTAINER_ID=$(${containerCmd})
-				if [ -z "$CONTAINER_ID" ]; then
-					echo "No running container found for ${appName}" >&2
-					exit 1
-				fi
-				docker exec "$CONTAINER_ID" psql -U ${databaseUser} -c "ALTER USER \\"${databaseUser}\\" WITH PASSWORD '${password}';"
-			`;
+			const container = await getServiceContainer(appName, serverId);
+			if (!container) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: `No running container found for ${appName}`,
+				});
+			}
+
+			const command = `docker exec ${container.Id} psql -U ${databaseUser} -d postgres -c "ALTER USER \\"${databaseUser}\\" WITH PASSWORD '${password}';"`;
 
 			await db.transaction(async (tx) => {
 				await tx

--- a/apps/dokploy/server/api/routers/redis.ts
+++ b/apps/dokploy/server/api/routers/redis.ts
@@ -10,7 +10,7 @@ import {
 	findRedisById,
 	getAccessibleServerIds,
 	getContainerLogs,
-	getServiceContainerCommand,
+	getServiceContainer,
 	getWebServerSettings,
 	IS_CLOUD,
 	rebuildDatabase,
@@ -418,15 +418,15 @@ export const redisRouter = createTRPCRouter({
 			const rd = await findRedisById(redisId);
 			const { appName, serverId, databasePassword } = rd;
 
-			const containerCmd = getServiceContainerCommand(appName);
-			const command = `
-				CONTAINER_ID=$(${containerCmd})
-				if [ -z "$CONTAINER_ID" ]; then
-					echo "No running container found for ${appName}" >&2
-					exit 1
-				fi
-				docker exec "$CONTAINER_ID" redis-cli -a '${databasePassword}' CONFIG SET requirepass '${password}'
-			`;
+			const container = await getServiceContainer(appName, serverId);
+			if (!container) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: `No running container found for ${appName}`,
+				});
+			}
+
+			const command = `docker exec ${container.Id} redis-cli -a '${databasePassword}' CONFIG SET requirepass '${password}'`;
 
 			await db.transaction(async (tx) => {
 				await tx


### PR DESCRIPTION
First upstream merge since the migration landed. **Zero conflicts.**

## What came in

Two commits — upstream's [#5114](https://github.com/Dokploy/dokploy/pull/5114) and its merge:

> `fix: use dockerode API instead of shell docker ps for changePassword container lookup`

The `changePassword` mutations for postgres/mysql/mariadb/mongo/redis found the running container with a shell one-liner through `execAsync`. When that failed for any reason `CONTAINER_ID` came back empty and the mutation reported the container as not running even though it was. Replaced with `getServiceContainer()`, the dockerode lookup already used by `mount.ts` and `schedules/utils.ts`.

It also fixes the postgres `ALTER USER`, which never selected a database and defaulted to one named after the user — a false `database "<user>" does not exist` whenever the db name differs from the username.

```diff
-const containerCmd = getServiceContainerCommand(appName);
-const command = `CONTAINER_ID=$(${containerCmd}) ... docker exec "$CONTAINER_ID" psql -U ${databaseUser} -c "..."`
+const container = await getServiceContainer(appName, serverId);
+if (!container) throw new TRPCError({ code: "BAD_REQUEST", ... });
+const command = `docker exec ${container.Id} psql -U ${databaseUser} -d postgres -c "..."`
```

## Zero conflicts, and that is the point

Five files, 50 insertions, 50 deletions, all in database routers — areas this fork never diverged in. Our divergence is concentrated in licensing, branding, tests and build config.

This is the first practical test of the fork discipline in `CLAUDE.md`, and it held: had we done the repo-wide reformat that was on the table, **every one of these five files would have conflicted**, and every future merge would too.

## Verified on the merged tree

| | |
|---|---|
| `bun run --filter '*' typecheck` | 0 errors, all four packages |
| `bun run build` | exit 0 |
| `bun test` | 749 tests; the same 4 pre-existing environmental failures, nothing new |
| `vitest` | 121 pass |
| `biome` | clean on all five files |

The 4 failures are `application.real.test.ts` needing swarm + nixpacks, which this machine lacks and CI installs. They fail identically before and after the merge.

Nothing of ours was touched — the diff against canary is exactly those five upstream files.

## One thing worth noting for later

`getServiceContainerCommand` is no longer used by the routers, but it is **not** dead: `utils/restore/libsql.ts` and `utils/restore/utils.ts` still call it. Left alone deliberately — deleting it would diverge from upstream in a file we have no other reason to touch.