### PR TITLE
ci: survive GHCR's secondary rate limit when publishing

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -61,6 +61,31 @@ jobs:
           cp apps/dokploy/.env.production.example apps/dokploy/.env.production
 
       - name: Build and push (${{ matrix.platform.arch }})
+        id: push
+        continue-on-error: true
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.image.dockerfile }}
+          platforms: linux/${{ matrix.platform.arch }}
+          push: true
+          tags: ${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.tag }}-${{ matrix.platform.arch }}
+          cache-from: type=gha,scope=${{ matrix.image.suffix }}-${{ matrix.platform.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image.suffix }}-${{ matrix.platform.arch }}
+
+      # Six of these jobs push to GHCR at once, and GHCR answers a burst with a
+      # secondary rate limit - "denied: permission_denied" wearing a 403, which
+      # reads like a credentials problem and is not. It killed the publish for
+      # canary twice (runs 32151479013 and 32152177649), leaving the tag stale.
+      #
+      # The layers are already built and cached by this point, so a retry is
+      # cheap: it re-pushes rather than rebuilding.
+      - name: Back off before retrying
+        if: steps.push.outcome == 'failure'
+        run: sleep $(( (RANDOM % 60) + 60 ))
+
+      - name: Wait out the rate limit and retry the push
+        if: steps.push.outcome == 'failure'
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -79,6 +104,10 @@ jobs:
     permissions:
       packages: write
     strategy:
+      # Serialised deliberately: these create six tags between them and take
+      # seconds each, so running them at once only adds to the GHCR burst that
+      # the retry above exists to survive.
+      max-parallel: 1
       matrix:
         suffix: ["", "-api", "-schedules"]
     steps:
@@ -96,10 +125,21 @@ jobs:
         run: |
           image="$(echo "${REGISTRY}/${{ github.repository }}" | tr '[:upper:]' '[:lower:]')${{ matrix.suffix }}"
           if [ "${{ github.ref }}" = "refs/heads/main" ]; then tag="latest"; else tag="canary"; fi
-          docker buildx imagetools create -t "${image}:${tag}" \
+          # Same secondary rate limit as the build push; retry rather than
+          # leaving a half-published set of tags behind.
+          retry() {
+            for attempt in 1 2 3; do
+              "$@" && return 0
+              echo "attempt $attempt failed, backing off" >&2
+              sleep $(( attempt * 30 ))
+            done
+            return 1
+          }
+
+          retry docker buildx imagetools create -t "${image}:${tag}" \
             "${image}:${tag}-amd64" \
             "${image}:${tag}-arm64"
-          docker buildx imagetools create -t "${image}:${{ github.sha }}" \
+          retry docker buildx imagetools create -t "${image}:${{ github.sha }}" \
             "${image}:${tag}-amd64" \
             "${image}:${tag}-arm64"
           echo "Published ${image}:${tag} (amd64 + arm64)"
@@ -119,7 +159,7 @@ jobs:
               v*) ;;
               *) version="v${version}" ;;
             esac
-            docker buildx imagetools create -t "${image}:${version}" \
+            retry docker buildx imagetools create -t "${image}:${version}" \
               "${image}:${tag}-amd64" \
               "${image}:${tag}-arm64"
             echo "Published ${image}:${version} (amd64 + arm64)"


### PR DESCRIPTION
The publish workflow failed **twice** on canary — runs [32151479013](https://github.com/SashaGoncharov19/dokploy-bun/actions/runs/32151479013) and [32152177649](https://github.com/SashaGoncharov19/dokploy-bun/actions/runs/32152177649) — and each time left the `canary` tag **stale while the PR checks stayed green**. That is the nasty part: nothing in the PR tells you the image never shipped.

## The error lies about itself

```
failed to push ghcr.io/.../dokploy-bun:canary-arm64: denied: permission_denied
"You have exceeded a secondary rate limit"
```

GHCR answers a burst with a **403 wearing `permission_denied`**, which reads like a broken token or missing `packages: write`. It is neither — it is "too fast".

The burst is ours: six matrix jobs (3 images × 2 arches) push simultaneously, then three manifest jobs create six more tags between them.

## Changes

- **Retry the build push.** `continue-on-error` on the push, with a second attempt behind it. The layers are built and cached by then, so the retry re-pushes rather than rebuilding.
- **Randomised 60–120s backoff** before that retry, so six jobs that failed together do not all return together.
- **Serialise the manifest matrix.** Each job takes seconds and creates two tags; running the three at once only feeds the burst.
- **Three-attempt retry with growing backoff** on the `imagetools create` calls — the same limit applies there, and a partial failure leaves some tags published and others not.

## Scope

`publish-images.yml` only. The bun 1.4.0 version bump that started this investigation is deliberately **not** in here — it touches the Docker base image, which needs a build-and-boot check before it ships, and that is a separate PR.